### PR TITLE
mc-sema: fix Pin download on cmake 2.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,10 +35,9 @@ boost/tools/build/CMake/install_me/BoostConfigVersionAgnostic.cmake
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).
 #==============================================================================#
-./build
-./package
+build
+package
 *.deb
 *.rpm
-./build
 ./mc-sema/validator/valTool/obj-ia32
 # Clang, which is tracked independently.

--- a/mc-sema/CMakeLists.txt
+++ b/mc-sema/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules"
 )
-	
+
 set(PROTOBUF_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/protobuf-2.5.0)
 if( WIN32 OR CYGWIN)
   # MinGW warns if -fvisibility-inlines-hidden is used.
@@ -100,17 +100,17 @@ if(NOT PIN_FOUND AND NOT WIN32)
 
 	if(UNIX)
 		set(PIN_DOWNLOAD_URL https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-67254-gcc.4.4.7-linux.tar.gz)
-		set(PIN_DOWNLOAD_HASH 4499cfed383f362a0c74560a3ee66a5f117bea95f40067224ddf3c2606c77006)
+		set(PIN_DOWNLOAD_HASH 792eaaa199e9deba84cde79858e93ffc)
 	endif(UNIX)
 
 	if(APPLE)
 		set(PIN_DOWNLOAD_URL https://software.intel.com/sites/landingpage/pintool/downloads/pin-2.14-67254-clang.5.1-mac.tar.gz)
-		set(PIN_DOWNLOAD_HASH b715d995bac010fd04c5c33c8efdcd6e2e42db8568a42071cd9a90d9a989e337)
+		set(PIN_DOWNLOAD_HASH 0f93c64484d039ceca828cd2909d321b)
 	endif(APPLE)
 
 	ExternalProject_add(Pin
 		URL ${PIN_DOWNLOAD_URL}
-		URL_HASH SHA256=${PIN_DOWNLOAD_HASH}
+		URL_MD5 ${PIN_DOWNLOAD_HASH}
 		CONFIGURE_COMMAND ""
 		BUILD_COMMAND ""
 		SOURCE_DIR pin
@@ -121,7 +121,6 @@ if(NOT PIN_FOUND AND NOT WIN32)
 	set(PIN_EXECUTABLE ${CMAKE_CURRENT_BINARY_DIR}/pin/pin)
 
 	add_subdirectory(validator)
-	
 endif(NOT PIN_FOUND AND NOT WIN32)
 
 if(WIN32 AND PIN_FOUND)

--- a/mc-sema/cmake/modules/FindPin.cmake
+++ b/mc-sema/cmake/modules/FindPin.cmake
@@ -1,6 +1,6 @@
 set(_PIN_NAMES pin)
 
-find_program(PIN_EXECUTABLE 
+find_program(PIN_EXECUTABLE
 	NAMES ${_PIN_NAMES}
 	PATHS "$ENV{PIN_HOME}" "${CMAKE_SOURCE_DIR}/thirdparty/win32/pin/ia32/bin" "C:/pin-2.10-45467-msvc10-ia32_intel64-windows/ia32/bin" "C:/pin/ia32/bin" "/usr/bin" "/opt/bin" "/usr/local/bin" "/bin" "/opt/pin"
 	)

--- a/mc-sema/validator/CMakeLists.txt
+++ b/mc-sema/validator/CMakeLists.txt
@@ -1,5 +1,5 @@
 if("${TARGET}" STREQUAL "X86_64")
    add_subdirectory(x86_64)
 else()
-  add_subdirectory(x86)
+   add_subdirectory(x86)
 endif("${TARGET}" STREQUAL "X86_64")


### PR DESCRIPTION
cmake 2.8 does not support URL_HASH, only URL_MD5.