### PR TITLE
Implement an inline assembly fallback for unsupported instructions.

### DIFF
--- a/mc-sema/peToCFG/inst_decoder_fe.h
+++ b/mc-sema/peToCFG/inst_decoder_fe.h
@@ -46,6 +46,7 @@ private:
   const llvm::MCDisassembler  *DisAsm;
   llvm::Triple                 *TT;
   const llvm::Target           *target;
+  llvm::MCContext             *Ctx;
 
 public:
   LLVMByteDecoder(void)
@@ -90,7 +91,7 @@ public:
                                       *STI);
     LASSERT( this->IP, "this->IP" );
 
-    llvm::MCContext *Ctx = new llvm::MCContext(AsmInfo, MRI, nullptr);
+    this->Ctx = new llvm::MCContext(AsmInfo, MRI, nullptr);
     this->DisAsm = target->createMCDisassembler(*this->STI, *Ctx );
 
     LASSERT( this->DisAsm, "this->DisAsm" );
@@ -149,7 +150,7 @@ public:
                                       *STI);
     LASSERT( this->IP, "this->IP" );
 
-    llvm::MCContext *Ctx = new llvm::MCContext(AsmInfo, MRI, nullptr);
+    this->Ctx = new llvm::MCContext(AsmInfo, MRI, nullptr);
     this->DisAsm = target->createMCDisassembler(*this->STI, *Ctx );
 
     LASSERT( this->DisAsm, "this->DisAsm" );
@@ -157,6 +158,7 @@ public:
     return;
   }
 
+  llvm::MCContext *getContext() { return this->Ctx; }
   llvm::MCInstPrinter *getPrinter(void) { return this->IP; }
   InstPtr getInstFromBuff(VA, llvm::MemoryObject *);
 };

--- a/mc-sema/peToCFG/peToCFG.cpp
+++ b/mc-sema/peToCFG/peToCFG.cpp
@@ -46,7 +46,8 @@ NativeModule::NativeModule(string modName, list<NativeFunctionPtr> f,
       callGraph(f.size()),
       nextID(0),
       nameStr(modName),
-      MyPrinter(p) {
+      MyPrinter(p),
+      ctxt(nullptr) {
 
   return;
 }
@@ -641,6 +642,7 @@ NativeModulePtr readProtoBuf(std::string fName, const llvm::Target *T) {
 
     cout << "Setting target..." << endl;
     m->setTarget(T);
+    m->setMCContext(decode.getContext());
     cout << "Done setting target" << endl;
 
     //populate the module with externals calls

--- a/mc-sema/peToCFG/peToCFG.h
+++ b/mc-sema/peToCFG/peToCFG.h
@@ -793,6 +793,8 @@ class NativeModule {
   llvm::MCInstPrinter *get_printer(void) {
     return this->MyPrinter;
   }
+  const llvm::MCContext *getMCContext() const { return ctxt; }
+  void setMCContext(llvm::MCContext *c) { ctxt = c; }
 
   //add a data section from a COFF object
   void addDataSection(VA, std::vector<uint8_t> &);
@@ -831,6 +833,7 @@ class NativeModule {
   void setTarget(const llvm::Target *T) {
     this->target = T;
   }
+  const llvm::Target *getTarget() const { return this->target; }
 
   void setTargetTriple(const std::string &triple) {
     this->triple = llvm::Triple(triple);
@@ -858,6 +861,7 @@ class NativeModule {
   std::list<DataSection> dataSecs;
   std::list<ExternalCodeRefPtr> extCalls;
   std::list<ExternalDataRefPtr> extData;
+  llvm::MCContext *ctxt;
 
  public:
   std::unordered_map<VA, MCSOffsetTablePtr> offsetTables;


### PR DESCRIPTION
This won't support all cases (256-bit and 512-bit instructions for sure), but
this should allow for correctness on unknown instructions, even if the generated
output will cause the optimizers to throw their hands up in the air.

I tested this out using AESNI instructions because I can't imagine anyone taking the time to actually write the tables for these to raise them to intrinsics.

FWIW, the use of template parameters for R_READ/R_WRITE as opposed to a parameter made this much harder than it had to be…