### PR TITLE
Fix description of MCSEMA_ENABLE_PIN_VALIDATOR option

### DIFF
--- a/mc-sema/CMakeLists.txt
+++ b/mc-sema/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-option(MCSEMA_ENABLE_PIN_VALIDATOR ON)
+option(MCSEMA_ENABLE_PIN_VALIDATOR "Use Intel Pin to test instruction semantics" OFF)
 
 set(CMAKE_MODULE_PATH
   ${CMAKE_MODULE_PATH}


### PR DESCRIPTION
I made a little mistake in my previous PR: CMake always uses the second argument of "option" as the description, not the default value, so here the description ended being "ON":
`option(MCSEMA_ENABLE_PIN_VALIDATOR ON)`
I set the default value to OFF now since most people won't need Pin anyway.