### PR TITLE
Bootstrap fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ tools/dist/*
 tools/mcsema_disass.egg-info/*
 tools/mcsema_disass/ida/CFG_pb2.py
 
+bin
 
 #==============================================================================#
 # Directories to ignore (do not add trailing '/'s, they skip symlinks).

--- a/README.md
+++ b/README.md
@@ -109,8 +109,13 @@ git clone git@github.com:trailofbits/mcsema.git --depth 1
 ##### Run the bootstrap script
 ```shell
 cd mcsema
-./bootstrap.sh Release
+./bootstrap.sh --build Release
 ```
+
+The Linux bootstrap script supports two configuration options:
+
+  * `--prefix`: The installation directory prefix for mcsema-lift. Defaults to the directory containing the bootstrap script.
+  * `--build`: Set the build type. Defaults to `Debug`
 
 #### On Windows
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -101,6 +101,8 @@ fi
 echo "[+] Installing the disassembler"
 sudo python ${DIR}/tools/setup.py install
 
+PROCS=$(nproc)
+
 # Create makefiles
 echo "[+] Creating Makefiles"
 pushd ${BUILD_DIR}
@@ -108,6 +110,7 @@ MCSEMA_DIR=$(realpath ${DIR})
 BUILD_DIR=$(realpath ${BUILD_DIR})
 LLVM_DIR=$(realpath ${LLVM_DIR})
 GEN_DIR=$(realpath ${GEN_DIR})
+INSTALL_DIR=${MCSEMA_DIR}
 
 echo "[x] Building LLVM"
 mkdir -p llvm
@@ -118,13 +121,14 @@ CFLAGS="${DEBUG_BUILD_ARGS}" \
 CXXFLAGS="${DEBUG_BUILD_ARGS}" \
 cmake \
   -G "Unix Makefiles" \
+  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DLLVM_TARGETS_TO_BUILD="X86" \
   -DLLVM_INCLUDE_EXAMPLES=OFF \
   -DLLVM_INCLUDE_TESTS=OFF \
   ${LLVM_DIR}
 
-make -j4
+make -j${PROCS}
 popd
 
 echo "[x] Creating Makefiles"
@@ -135,7 +139,8 @@ CFLAGS="-g3 -O0" \
 CXXFLAGS="-g3 -O0" \
 cmake \
   -G "Unix Makefiles" \
-  -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+  -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   -DLLVM_DIR="${BUILD_DIR}/llvm/share/llvm/cmake" \
   -DMCSEMA_LLVM_DIR="${LLVM_DIR}" \
   -DMCSEMA_DIR="${MCSEMA_DIR}" \
@@ -143,8 +148,8 @@ cmake \
   -DMCSEMA_GEN_DIR="${GEN_DIR}" \
   ${MCSEMA_DIR}
 
-make -j4
-sudo make install
+make -j${PROCS}
+make install
 
 popd
- 
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,20 +3,65 @@
 
 set -e
 
+usage() {
+  echo "Usage:"
+  echo "$0 [--prefix <PREFIX>] [--build <BUILD TYPE>]"
+  echo "PREFIX: Installation directory prefix"
+  echo "BUILDTYPE: Built type (e.g. Debug, Release, etc.)"
+  exit 1
+}
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 BUILD_DIR=${DIR}/build
 THIRD_PARTY_DIR=${DIR}/third_party
 LLVM_DIR=${DIR}/third_party/llvm
-
 GEN_DIR=${DIR}/generated
 
+# default argument values
+# Debug Build
+BUILD_TYPE=Debug
+#Install to directory of the git clone
+PREFIX=$(readlink -f ${DIR})
+
+# taken from:
+# http://stackoverflow.com/questions/192249/how-do-i-parse-command-line-arguments-in-bash
+while [[ $# -gt 0 ]]
+do
+  key="$1"
+
+  case $key in
+      -p|--prefix)
+        PREFIX=$(readlink -f $2)
+        shift # past argument
+      ;;
+      -b|--build)
+        BUILD_TYPE="$2"
+        shift # past argument
+      ;;
+      *)
+        # unknown option
+        echo "Unknown option: $key"
+        usage
+      ;;
+  esac
+  shift # past argument or value
+done
+
+if [ ! -d "${PREFIX}" ]; then
+  echo "Cannot find installation prefix directory: ${PREFIX}"
+  exit 1
+else
+    echo "Installation directory prefix: ${PREFIX}"
+fi
+
 DEBUG_BUILD_ARGS=
-if [ $# -eq 0 ]; then
-  echo "No arguments supplied. Defaulting to DCMAKE_BUILD_TYPE=Release"
+if [[ "${BUILD_TYPE}" == "Debug" ]]; then
+  echo "Build type set to: ${BUILD_TYPE}"
+  echo "  Setting build arguments for DCMAKE_BUILD_TYPE=Debug"
   BUILD_TYPE=Debug
   DEBUG_BUILD_ARGS="-g3 -O0"
 else
-  BUILD_TYPE=$1
+  echo "Build type set to: ${BUILD_TYPE}"
 fi
 
 echo "[x] Installing dependencies via apt-get"
@@ -110,7 +155,6 @@ MCSEMA_DIR=$(realpath ${DIR})
 BUILD_DIR=$(realpath ${BUILD_DIR})
 LLVM_DIR=$(realpath ${LLVM_DIR})
 GEN_DIR=$(realpath ${GEN_DIR})
-INSTALL_DIR=${MCSEMA_DIR}
 
 echo "[x] Building LLVM"
 mkdir -p llvm
@@ -121,7 +165,7 @@ CFLAGS="${DEBUG_BUILD_ARGS}" \
 CXXFLAGS="${DEBUG_BUILD_ARGS}" \
 cmake \
   -G "Unix Makefiles" \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
   -DLLVM_TARGETS_TO_BUILD="X86" \
   -DLLVM_INCLUDE_EXAMPLES=OFF \
@@ -139,7 +183,7 @@ CFLAGS="-g3 -O0" \
 CXXFLAGS="-g3 -O0" \
 cmake \
   -G "Unix Makefiles" \
-  -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} \
+  -DCMAKE_INSTALL_PREFIX=${PREFIX} \
   -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   -DLLVM_DIR="${BUILD_DIR}/llvm/share/llvm/cmake" \
   -DMCSEMA_LLVM_DIR="${LLVM_DIR}" \

--- a/mcsema/cfgToLLVM/x86Helpers.cpp
+++ b/mcsema/cfgToLLVM/x86Helpers.cpp
@@ -31,10 +31,10 @@
 
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Intrinsics.h>
+#include <llvm/Support/CodeGen.h>
 
 #include "raiseX86.h"
 #include "Externals.h"
-#include "X86.h"
 #include "x86Helpers.h"
 #include "TransExcn.h"
 

--- a/mcsema/cfgToLLVM/x86Instrs.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs.cpp
@@ -31,11 +31,11 @@
 #include <llvm/IR/IntrinsicInst.h>
 #include <llvm/IR/Intrinsics.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Dispatch.h"
 
 #include "raiseX86.h"
-#include "X86.h"
-
 
 #include "JumpTables.h"
 

--- a/mcsema/cfgToLLVM/x86Instrs_Branches.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_Branches.cpp
@@ -42,12 +42,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Helpers.h"
 #include "x86Instrs_Branches.h"

--- a/mcsema/cfgToLLVM/x86Instrs_CMOV.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_CMOV.cpp
@@ -41,12 +41,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Helpers.h"
 #include "x86Instrs_CMOV.h"

--- a/mcsema/cfgToLLVM/x86Instrs_Jcc.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_Jcc.cpp
@@ -41,12 +41,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Helpers.h"
 #include "x86Instrs_Jcc.h"

--- a/mcsema/cfgToLLVM/x86Instrs_Misc.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_Misc.cpp
@@ -42,12 +42,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Helpers.h"
 #include "x86Instrs_MOV.h"

--- a/mcsema/cfgToLLVM/x86Instrs_Stack.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_Stack.cpp
@@ -42,12 +42,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Instrs_Stack.h"
 #include "x86Instrs_MOV.h"

--- a/mcsema/cfgToLLVM/x86Instrs_bitops.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_bitops.cpp
@@ -37,12 +37,13 @@
 
 #include <llvm/MC/MCInst.h>
 
+#include <llvm/Support/CodeGen.h>
+
 #include "mcsema/Arch/Arch.h"
 #include "mcsema/Arch/Dispatch.h"
 #include "mcsema/Arch/Register.h"
 
 #include "InstructionDispatch.h"
-#include "X86.h"
 #include "raiseX86.h"
 #include "x86Helpers.h"
 #include "x86Instrs_flagops.h"

--- a/mcsema/cfgToLLVM/x86_64Helpers.cpp
+++ b/mcsema/cfgToLLVM/x86_64Helpers.cpp
@@ -1,8 +1,9 @@
+#include <llvm/Support/CodeGen.h>
+#include <llvm/Support/Debug.h>
+
 #include "raiseX86.h"
 #include "Externals.h"
-#include "X86.h"
 #include "x86Helpers.h"
-#include "llvm/Support/Debug.h"
 
 using namespace std;
 using namespace llvm;


### PR DESCRIPTION
* Do not install mcsema for all users
* Use `nprocs` to figure out how many CPUs we have instead of hardcoding 4