### PR TITLE
Use 32-bit values when doing 32-bit memory moves

### DIFF
--- a/mcsema/cfgToLLVM/x86Instrs_MOV.cpp
+++ b/mcsema/cfgToLLVM/x86Instrs_MOV.cpp
@@ -605,7 +605,7 @@ static InstTransResult translate_MOV32mi(TranslationContext &ctx,
   auto &inst = ip->get_inst();
 
   if (ip->has_code_ref()) {
-    llvm::Value *addrInt = IMM_AS_DATA_REF(block, natM, ip);
+    llvm::Value *addrInt = IMM_AS_DATA_REF<32>(block, natM, ip);
     if (ip->has_mem_reference) {
       ret = doMIMovV<32>(ip, block, MEM_REFERENCE(0), addrInt);
     } else {
@@ -619,10 +619,10 @@ static InstTransResult translate_MOV32mi(TranslationContext &ctx,
         // * archGetImageBase is defined
         // * we are on win64
 
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
         data_v = doSubtractImageBase<32>(data_v, block);
       } else {
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
       }
       doMIMovV<32>(ip, block, MEM_REFERENCE(0), data_v);
     } else if (ip->has_mem_reference) {
@@ -634,10 +634,10 @@ static InstTransResult translate_MOV32mi(TranslationContext &ctx,
         // * archGetImageBase is defined
         // * we are on win64
 
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
         data_v = doSubtractImageBase<32>(data_v, block);
       } else {
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
       }
 
       doMIMovV<32>(ip, block, ADDR_NOREF(0), data_v);
@@ -826,7 +826,7 @@ static InstTransResult translate_MOV32ri(TranslationContext &ctx,
   auto &inst = ip->get_inst();
 
   if (ip->has_code_ref()) {
-    llvm::Value *addrInt = IMM_AS_DATA_REF(block, natM, ip);
+    llvm::Value *addrInt = IMM_AS_DATA_REF<32>(block, natM, ip);
     ret = doRIMovV<32>(ip, block, addrInt, OP(0));
   } else {
     if (ip->has_imm_reference) {
@@ -836,10 +836,10 @@ static InstTransResult translate_MOV32ri(TranslationContext &ctx,
         // * archGetImageBase is defined
         // * we are on win64
 
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
         data_v = doSubtractImageBase<32>(data_v, block);
       } else {
-        data_v = IMM_AS_DATA_REF(block, natM, ip);
+        data_v = IMM_AS_DATA_REF<32>(block, natM, ip);
       }
 
       ret = doRIMovV<32>(ip, block, data_v, OP(0));


### PR DESCRIPTION
* Use `IMM_AS_DATA_REF<32>` in MOV32mi, which will always write a 32-bit value. This would cause assertions in StoreInst on amd64 when the code was hit.