### PR TITLE
Fix weak symbol support

### DIFF
--- a/mcsema/Arch/Arch.cpp
+++ b/mcsema/Arch/Arch.cpp
@@ -561,7 +561,7 @@ llvm::Function *ArchAddExitPointDriver(llvm::Function *F) {
   }
 
   W = llvm::Function::Create(F->getFunctionType(),
-                             llvm::GlobalValue::ExternalLinkage, name, M);
+                             F->getLinkage(), name, M);
   W->setCallingConv(F->getCallingConv());
   W->addFnAttr(llvm::Attribute::NoInline);
   W->addFnAttr(llvm::Attribute::Naked);
@@ -611,7 +611,6 @@ llvm::Function *ArchAddExitPointDriver(llvm::Function *F) {
     TASSERT(false, "Unsupported OS for exit point driver.");
   }
 
-  F->setLinkage(llvm::GlobalValue::ExternalLinkage);  // TODO(artem): No-op?
   if (F->doesNotReturn()) {
     W->setDoesNotReturn();
   }

--- a/tools/mcsema_disass/defs/linux.txt
+++ b/tools/mcsema_disass/defs/linux.txt
@@ -20,7 +20,6 @@ __assert_fail 5 C N
 __cxa_atexit 5 C N
 __cxa_guard_acquire 5 C N
 __cxa_guard_release 5 C N
-__gmon_start__ 5 C N
 _ITM_deregisterTMCloneTable 5 C N
 _ITM_registerTMCloneTable 5 C N
 _Jv_RegisterClasses 5 C N


### PR DESCRIPTION
* Remove an unused entry for __gmon_start__ for linux defs
* Pass the linkage type to the arch specific driver generation