### PR TITLE
Fix disass checks

### DIFF
--- a/tools/mcsema_disass/__main__.py
+++ b/tools/mcsema_disass/__main__.py
@@ -52,6 +52,11 @@ def main(args=None):
       help='Binary to recover control flow graph from',
       required=True)
 
+  arg_parser.add_argument(
+      '--entrypoint',
+      help="The entrypoint where disassembly should begin",
+      required=True)
+
   args, command_args = arg_parser.parse_known_args()
 
   if not os.path.isfile(args.binary):

--- a/tools/mcsema_disass/__main__.py
+++ b/tools/mcsema_disass/__main__.py
@@ -7,10 +7,21 @@ import shutil
 import sys
 import tempfile
 import traceback
+import textwrap
 
+
+SUPPORTED_OS = ('linux', 'windows',)
+SUPPORTED_ARCH = ('x86', 'amd64',)
 
 def main(args=None):
-  arg_parser = argparse.ArgumentParser()
+  arg_parser = argparse.ArgumentParser(
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=textwrap.dedent("""\
+    Additional arguments are passed to the disassembler script directly. These include:
+    
+      --std_defs <file>       Load additional external function definitions from <file>
+      --pie-mode              Change disassembler heuristics to work on position independent code"""))
+
   arg_parser.add_argument(
       '--disassembler',
       help='Path to disassembler binary',
@@ -23,7 +34,7 @@ def main(args=None):
 
   arg_parser.add_argument(
       '--os',
-      help='Name of the OS. Valid names are linux, windows.',
+      help='Name of the OS. Valid names are {}'.format(SUPPORTED_OS),
       required=True)
 
   arg_parser.add_argument(
@@ -48,12 +59,14 @@ def main(args=None):
         args.binary))
     return 1
 
-  if args.arch not in ('x86', 'amd64'):
-    arg_parser.error("{} passed to --arch is not supported.".format(args.arch))
+  if args.arch not in SUPPORTED_ARCH:
+    arg_parser.error("{} passed to --arch is not supported. Valid options are: {}".format(
+      args.arch, SUPPORTED_ARCH))
     return 1
 
-  if args.os not in ('linux', 'windows'):
-    arg_parser.error("{} passed to --os is not supported.".format(args.os))
+  if args.os not in SUPPORTED_OS:
+    arg_parser.error("{} passed to --os is not supported. Valid options are: {}".format(
+      args.os, SUPPORTED_OS))
 
   args.binary = os.path.abspath(args.binary)
   args.output = os.path.abspath(args.output)
@@ -73,6 +86,18 @@ def main(args=None):
     if 'ida' in args.disassembler:
       import ida.disass
       ret = ida.disass.execute(args, command_args)
+
+      # in case IDA somehow says success, but no output was generated
+      if not os.path.isfile(args.output):
+          sys.stderr.write("Could not generate a CFG. Try using the --log_file option to see an error log.\n")
+          ret = 1
+
+      # The disassembler script probably threw an exception
+      if 0 == os.path.getsize(args.output):
+          sys.stderr.write("Generated an invalid (zero-sized) CFG. Please use the --log_file option to see an error log.\n")
+          # remove the zero-sized file
+          os.unlink(args.output)
+          ret = 1
 
     else:
       arg_parser.error("{} passed to --disassembler is not known.".format(

--- a/tools/mcsema_disass/ida/disass.py
+++ b/tools/mcsema_disass/ida/disass.py
@@ -36,6 +36,8 @@ def execute(args, command_args):
   script_cmd.append(args.arch)
   script_cmd.append("--os")
   script_cmd.append(args.os)
+  script_cmd.append("--entrypoint")
+  script_cmd.append(args.entrypoint)
   script_cmd.extend(command_args)  # Extra, script-specific arguments.
 
   cmd = []


### PR DESCRIPTION
Closes #149 #148 #145 

* Documents `--pie-mode` and `--std_defs`
* Checks that a CFG was generated
* Makes `--entrypoint` required