### PR TITLE
minor fix: typedef of VA makes compilation on 32-bit machines fail

### DIFF
--- a/mcsema/Arch/Arch.h
+++ b/mcsema/Arch/Arch.h
@@ -74,7 +74,7 @@ class MCInst;
 
 }  // namespace llvm
 
-typedef uintptr_t VA;
+typedef uint64_t VA;
 
 enum SystemArchType {
   _X86_,

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -49,11 +49,7 @@ namespace llvm {
 class Target;
 }  // namespace llvm
 
-#ifdef __x86_64__
-typedef uint64_t VA;
-#else
 typedef uintptr_t VA;
-#endif
 
 class NativeInst;
 typedef NativeInst *NativeInstPtr;

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -49,7 +49,7 @@ namespace llvm {
 class Target;
 }  // namespace llvm
 
-typedef uintptr_t VA;
+typedef uint64_t VA;
 
 class NativeInst;
 typedef NativeInst *NativeInstPtr;

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -49,7 +49,11 @@ namespace llvm {
 class Target;
 }  // namespace llvm
 
+#ifdef __x86_64__
 typedef uint64_t VA;
+#else
+typedef uintptr_t VA;
+#endif
 
 class NativeInst;
 typedef NativeInst *NativeInstPtr;


### PR DESCRIPTION
Just added ifdefs:
#ifdef __x86_64__
typedef uint64_t VA;
#else
typedef uintptr_t VA;
#endif

Hopefully that's how you guys check for 64-bit/32-bitness