### PR TITLE
Windows bootstrap fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,61 @@ if(WIN32)
   add_compile_options(
     /nologo
     /DGOOGLE_PROTOBUF_NO_RTTI
-    /W3)
+    /W3
+    /wd4141 # Suppress ''modifier' : used more than once' (because of __forceinline combined with inline)
+    /wd4146 # Suppress 'unary minus operator applied to unsigned type, result still unsigned'
+    /wd4180 # Suppress 'qualifier applied to function type has no meaning; ignored'
+    /wd4244 # Suppress ''argument' : conversion from 'type1' to 'type2', possible loss of data'
+    /wd4258 # Suppress ''var' : definition from the for loop is ignored; the definition from the enclosing scope is used'
+    /wd4267 # Suppress ''var' : conversion from 'size_t' to 'type', possible loss of data'
+    /wd4291 # Suppress ''declaration' : no matching operator delete found; memory will not be freed if initialization throws an exception'
+    /wd4345 # Suppress 'behavior change: an object of POD type constructed with an initializer of the form () will be default-initialized'
+    /wd4351 # Suppress 'new behavior: elements of array 'array' will be default initialized'
+    /wd4355 # Suppress ''this' : used in base member initializer list'
+    /wd4456 # Suppress 'declaration of 'var' hides local variable'
+    /wd4457 # Suppress 'declaration of 'var' hides function parameter'
+    /wd4458 # Suppress 'declaration of 'var' hides class member'
+    /wd4459 # Suppress 'declaration of 'var' hides global declaration'
+    /wd4503 # Suppress ''identifier' : decorated name length exceeded, name was truncated'
+    /wd4624 # Suppress ''derived class' : destructor could not be generated because a base class destructor is inaccessible'
+    /wd4722 # Suppress 'function' : destructor never returns, potential memory leak
+    /wd4800 # Suppress ''type' : forcing value to bool 'true' or 'false' (performance warning)'
+    /wd4100 # Suppress 'unreferenced formal parameter'
+    /wd4127 # Suppress 'conditional expression is constant'
+    /wd4512 # Suppress 'assignment operator could not be generated'
+    /wd4505 # Suppress 'unreferenced local function has been removed'
+    /wd4610 # Suppress '<class> can never be instantiated'
+    /wd4510 # Suppress 'default constructor could not be generated'
+    /wd4702 # Suppress 'unreachable code'
+    /wd4245 # Suppress 'signed/unsigned mismatch'
+    /wd4706 # Suppress 'assignment within conditional expression'
+    /wd4310 # Suppress 'cast truncates constant value'
+    /wd4701 # Suppress 'potentially uninitialized local variable'
+    /wd4703 # Suppress 'potentially uninitialized local pointer variable'
+    /wd4389 # Suppress 'signed/unsigned mismatch'
+    /wd4611 # Suppress 'interaction between '_setjmp' and C++ object destruction is non-portable'
+    /wd4805 # Suppress 'unsafe mix of type <type> and type <type> in operation'
+    /wd4204 # Suppress 'nonstandard extension used : non-constant aggregate initializer'
+    /wd4577 # Suppress 'noexcept used with no exception handling mode specified; termination on exception is not guaranteed'
+    /wd4091 # Suppress 'typedef: ignored on left of '' when no variable is declared'
+        # C4592 is disabled because of false positives in Visual Studio 2015
+        # Update 1. Re-evaluate the usefulness of this diagnostic with Update 2.
+    /wd4592 # Suppress ''var': symbol will be dynamically initialized (implementation limitation)
+
+	# Ideally, we'd like this warning to be enabled, but MSVC 2013 doesn't
+	# support the 'aligned' attribute in the way that clang sources requires (for
+	# any code that uses the LLVM_ALIGNAS macro), so this is must be disabled to
+	# avoid unwanted alignment warnings.
+	# When we switch to requiring a version of MSVC that supports the 'alignas'
+	# specifier (MSVC 2015?) this warning can be re-enabled.
+    /wd4324 # Suppress 'structure was padded due to __declspec(align())'
+    /D_CRT_SECURE_NO_DEPRECATE
+    /D_CRT_SECURE_NO_WARNINGS
+    /D_CRT_NONSTDC_NO_DEPRECATE
+    /D_CRT_NONSTDC_NO_WARNINGS
+    /D_SCL_SECURE_NO_DEPRECATE
+    /D_SCL_SECURE_NO_WARNINGS
+    )
 else()
   add_compile_options(
     -g3

--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -1,6 +1,6 @@
 rem Copyright 2017 Peter Goodman, all rights reserved.
 
-@echo off
+rem @echo off
 
 set DIR=%~dp0
 if "%DIR:~-1%"=="\" set DIR=%DIR:~0,-1%
@@ -12,44 +12,59 @@ set LLVM_DIR=%THIRD_PARTY_DIR%\llvm
 set PROTO_DIR=%THIRD_PARTY_DIR%\protobuf
 set GEN_DIR=%DIR%\generated
 
-echo [+] Upgrading PIP
-pip install --upgrade pip
-
-echo Go into the mcsema directory
-pushd "%~dp0" 
-
 echo [+] Creating directories
 if not exist third_party mkdir third_party
 if not exist build mkdir build
 if not exist generated mkdir generated
 
+set PATH=%ProgramFiles%\7-zip\;%PATH%
+if defined ProgramFiles(x86) (
+    set PATH=%ProgramFiles(x86)%\7-zip\;%PATH%
+)
+
+REM sanity checks for installed software
+where 7z >NUL 2>NUL
+if not %ERRORLEVEL% == 0 (
+    echo "The 7z command is not found. Attempting to install"
+    powershell -Command "(new-object System.Net.WebClient).DownloadFile('http://www.7-zip.org/a/7z1604.msi','%THIRD_PARTY_DIR%\7z.msi')"
+    msiexec /quiet /i %THIRD_PARTY_DIR%\7z.msi
+)
+where 7z >NUL 2>NUL
+if not %ERRORLEVEL% == 0 (
+    echo "Could not install 7zip, aborting"
+    exit /B 1
+)
+where cmake >NUL 2>NUL
+if not %ERRORLEVEL% == 0 (
+    echo "The cmake command is not found. Please install cmake"
+    exit /B 1
+)
+where cl.exe >NUL 2>NUL
+if not %ERRORLEVEL% == 0 (
+    echo "The Visual Studio Compiler s not found. Please run from a Visual Studio command prompt"
+    exit /B 1
+)
+
+REM echo [+] Upgrading PIP
+REM pip install --upgrade pip
+
+echo Go into the mcsema directory
+pushd "%~dp0" 
+
 echo [+] Download and extract Google Protocol Buffers 2.6.1
 pushd third_party
-if exist protobuf goto compile_proto
-wget https://github.com/google/protobuf/releases/download/v2.6.1/protobuf-2.6.1.zip
-unzip protobuf-2.6.1.zip
-move protobuf-2.6.1 protobuf
-:compile_proto
+if exist protoc.exe goto get_llvm
+powershell -Command "(new-object System.Net.WebClient).DownloadFile('https://github.com/google/protobuf/releases/download/v2.6.1/protoc-2.6.1-win32.zip','protoc-2.6.1-win32.zip')"
+7z -bd x -y protoc-2.6.1-win32.zip > NUL
 
-rem Compile protobuf to get protoc.exe
-pushd protobuf
-if not exist build mkdir build
-pushd build
-"C:\Program Files\CMake\bin\cmake.exe" ^
-  -G "Visual Studio 14 2015 Win64" ^
-  -DPROTOBUF_ROOT="%PROTO_DIR%" ^
-  %MCSEMA_DIR%\cmake\protobuf
-msbuild /p:Configuration=Release /p:Platform="x64" Protobuf.sln
-popd
-popd
-
+:get_llvm
 popd
 
 if exist %GEN_DIR%\CFG.pb.h goto download_llvm
 echo [+] Auto-generating protobuf files
 set PROTO_PATH=%MCSEMA_DIR%\mcsema\CFG
 pushd %GEN_DIR%
-%THIRD_PARTY_DIR%\protobuf\build\protoc\Release\protoc.exe ^
+%THIRD_PARTY_DIR%\protoc.exe ^
   --cpp_out "%GEN_DIR%" ^
   --python_out "%GEN_DIR%" ^
   --proto_path "%PROTO_PATH%" ^
@@ -60,46 +75,83 @@ popd
 echo [+] Download and extract LLVM
 pushd third_party
 if exist llvm goto compile_llvm
-wget http://releases.llvm.org/3.8.1/llvm-3.8.1.src.tar.xz
-"C:\Program Files\7-Zip\7z.exe" x -y llvm-3.8.1.src.tar.xz
-"C:\Program Files\7-Zip\7z.exe" x -y llvm-3.8.1.src.tar
+
+powershell -Command "(new-object System.Net.WebClient).DownloadFile('http://releases.llvm.org/3.8.1/llvm-3.8.1.src.tar.xz', 'llvm-3.8.1.src.tar.xz')"
+7z -bd x -y llvm-3.8.1.src.tar.xz > NUL
+7z -bd x -y llvm-3.8.1.src.tar > NUL
 move llvm-3.8.1.src llvm
 :compile_llvm
+
+if "%PROCESSOR_ARCHITECTURE%"=="AMD64" ( 
+    set BITNESS=Win64 ) else (
+    set BITNESS=)
+
+set VSBUILD=UNKNOWN
+cl /? 2>&1 | findstr /C:"Version 18" > nul
+if %ERRORLEVEL% == 0 (
+    set VSBUILD=Visual Studio 12 2013%BITNESS%
+) 
+cl /? 2>&1 | findstr /C:"Version 19" > nul
+if %ERRORLEVEL% == 0 (
+    set VSBUILD=Visual Studio 14 2015%BITNESS%
+) 
+
+if "%VSBUILD%"=="UNKNOWN" (
+    echo "Could not identify Visual Studio Version"
+    echo "This build requires at least VS 2013"
+    exit /B 1
+)
+
+echo "Found Visual Studio: %VSBUILD%"
 if not exist "%BUILD_DIR%\llvm" mkdir "%BUILD_DIR%\llvm"
 pushd "%BUILD_DIR%\llvm"
-"C:\Program Files\CMake\bin\cmake.exe" ^
-  -G "NMake Makefiles" ^
+cmake.exe ^
+  -G "%VSBUILD%" ^
   -DLLVM_TARGETS_TO_BUILD="X86" ^
   -DLLVM_INCLUDE_EXAMPLES=OFF ^
   -DLLVM_INCLUDE_TESTS=OFF ^
   -DCMAKE_BUILD_TYPE="Release" ^
   %LLVM_DIR%
-nmake
+cmake --build . --config Release
   
 popd
 popd
 
-if exist %GEN_DIR%\ELF_32_linux.S goto create_mcsema_files
-echo [+] Generating runtimes
-cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_ELF_32_linux.cpp
-a.out.exe > %GEN_DIR%\ELF_32_linux.S
+REM cl does not have a flag to specify 32-bit or 64-bit output
+REM TODO(artem): Use the path of cl.exe to find the other CL that will 
+REM output the correct bitness code
+if "%BITNESS%"=="Win64" (
 
-cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_ELF_64_linux.cpp
-a.out.exe > %GEN_DIR%\ELF_64_linux.S
+    if exist %GEN_DIR%\ELF_64_linux.S goto create_mcsema_files
+    echo [+] Generating runtimes
+    
+    cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_ELF_64_linux.cpp
+    a.out.exe > %GEN_DIR%\ELF_64_linux.S
+    
+    cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_PE_64_windows.cpp
+    a.out.exe > %GEN_DIR%\PE_64_windows.asm
+    del a.out.exe a.out.obj
 
-cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_PE_32_windows.cpp
-a.out.exe > %GEN_DIR%\PE_32_windows.asm
+) else (
 
-cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_PE_64_windows.cpp
-a.out.exe > %GEN_DIR%\PE_64_windows.asm
+    if exist %GEN_DIR%\ELF_32_linux.S goto create_mcsema_files
+    echo [+] Generating runtimes
 
-del a.out.exe a.out.obj
+    cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_ELF_32_linux.cpp
+    a.out.exe > %GEN_DIR%\ELF_32_linux.S
+    
+    cl.exe /nologo /Fe:a.out.exe /Fo:a.out.obj %MCSEMA_DIR%\mcsema\Arch\X86\Runtime\print_PE_32_windows.cpp
+    a.out.exe > %GEN_DIR%\PE_32_windows.asm
+    del a.out.exe a.out.obj
+)
+
 :create_mcsema_files
 
 rem Create McSema build files
 pushd build
 
-"C:\Program Files\CMake\bin\cmake.exe" ^
+cmake.exe ^
+  -G "%VSBUILD%"
   -DLLVM_DIR="%BUILD_DIR%\llvm\share\llvm\cmake" ^
   -DMCSEMA_LLVM_DIR="%LLVM_DIR%" ^
   -DMCSEMA_DIR="%DIR%" ^
@@ -107,7 +159,7 @@ pushd build
   -DMCSEMA_GEN_DIR="%GEN_DIR%" ^
   -DCMAKE_BUILD_TYPE="Release" ^
   %MCSEMA_DIR%
-nmake
+cmake --build . --config Release
 
 popd
 

--- a/mcsema/Arch/X86/Runtime/State.h
+++ b/mcsema/Arch/X86/Runtime/State.h
@@ -18,9 +18,14 @@
 #define __x86_64__
 #endif
 
+#ifdef _WIN32
+#define ALIGN(x) __declspec( align( x ) )
+#else
+#define ALIGN(x) alignas(x)
+#endif
 
 #ifdef _WIN32
-typedef struct alignas(16) __uint128_t {
+typedef struct ALIGN(16)  __uint128_t {
     char pad[16];
 } PACKED uint128_t;
 #else
@@ -41,7 +46,7 @@ typedef uint32_t reg_t;
 #endif
 
 //structure for register state
-struct alignas(16) RegState {
+struct ALIGN(16) RegState {
 
   reg_t RIP;
   reg_t RAX;
@@ -124,4 +129,7 @@ struct alignas(16) RegState {
   uint128_t XMM14;
   uint128_t XMM15;
 };
+#ifdef _WIN32
+#pragma pack(pop)
+#endif
 

--- a/mcsema/Arch/X86/Semantics/SSE.cpp
+++ b/mcsema/Arch/X86/Semantics/SSE.cpp
@@ -1406,7 +1406,7 @@ template<int width, int elemwidth, llvm::CmpInst::Predicate cmp_op>
 static llvm::Value* do_SATURATED_SUB(llvm::BasicBlock *&b, llvm::Value *v1,
                                      llvm::Value *v2) {
   NASSERT(width % elemwidth == 0);
-  constexpr int elem_count = width / elemwidth;
+  int elem_count = width / elemwidth;
   llvm::Type *elem_ty = nullptr;
   llvm::VectorType *vt = nullptr;
   llvm::Type *int32ty = llvm::Type::getIntNTy(b->getContext(), 32);

--- a/mcsema/BC/Util.h
+++ b/mcsema/BC/Util.h
@@ -222,7 +222,6 @@ void dataSectionToTypesContents(const std::list<DataSection> &globaldata,
 #define GENERIC_TRANSLATION_MI(NAME, NOREFS, MEMREF, IMMREF, TWOREFS) \
     static InstTransResult translate_ ## NAME ( \
         TranslationContext &ctx, llvm::BasicBlock *&block) { \
-      InstTransResult ret; \
       auto natM = ctx.natM; \
       auto F = ctx.F; \
       auto ip = ctx.natI; \
@@ -243,7 +242,6 @@ void dataSectionToTypesContents(const std::list<DataSection> &globaldata,
 #define GENERIC_TRANSLATION_REF(NAME, NOREFS, HASREF) \
     static InstTransResult translate_ ## NAME ( \
         TranslationContext &ctx, llvm::BasicBlock *&block) { \
-      InstTransResult ret;\
       auto natM = ctx.natM; \
       auto F = ctx.F; \
       auto ip = ctx.natI; \


### PR DESCRIPTION
* Lower build requirements to Win7 and VS2013 (sorry, `constexpr`)
* Disable lots of unneeded warnings in LLVM code that we trigger by linking to it
* Remove dependencies on wget, automatically install 7zip
* Use cmake --build instead of msbuild
* Fix asm file generation