### PR TITLE
Add integration tests for `ls --recursive`

### DIFF
--- a/tests/linux/amd64/config.json
+++ b/tests/linux/amd64/config.json
@@ -24,6 +24,10 @@
         },
         "width test": {
             "args": ["--width=100", "-d", "/usr"]
+        },
+        "recurisve option": {
+            "_comment": "The --recursive option triggers a call that used to fail during cfg recovery",
+            "args": ["--recursive", "--width=100", "-d", "/usr"]
         }
     },
 

--- a/tests/linux/amd64/expected_outputs.json
+++ b/tests/linux/amd64/expected_outputs.json
@@ -30,6 +30,17 @@
       "expected_stderr": "", 
       "expected_stdout": "L3Vzcgo="
     }, 
+    "recurisve option": {
+      "_comment": "The --recursive option triggers a call that used to fail during cfg recovery", 
+      "args": [
+        "--recursive", 
+        "--width=100", 
+        "-d", 
+        "/usr"
+      ], 
+      "expected_stderr": "", 
+      "expected_stdout": "L3Vzcgo="
+    }, 
     "width test": {
       "args": [
         "--width=100", 


### PR DESCRIPTION
Add integration tests for ls `ls --recursive`. I used the backticks in my commit message in the shell, so the commit message is nice and crazy.