### PR TITLE
Requiring CMake 3.1 to make CMAKE_CXX_STANDARD switch effective

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2017 Peter Goodman (peter@trailofbits.com), all rights reserved.
 
 project(mcsema)
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.1)
 
 if(WIN32)
   SET(CMAKE_EXE_LINKER_FLAGS "/LARGEADDRESSAWARE ${CMAKE_EXE_LINKER_FLAGS}")


### PR DESCRIPTION
The CMAKE_CXX_STANDARD switch is not recognised before CMake 3.1. Hence, the build is broken when attempting to use CMake 2.8.1, as I did.

This change inhibits the usage of too old CMake.