### PR TITLE
Bugfixes

### DIFF
--- a/mcsema/Arch/X86/Semantics/ADD.cpp
+++ b/mcsema/Arch/X86/Semantics/ADD.cpp
@@ -50,13 +50,6 @@
 
 using namespace llvm;
 
-static InstTransResult doNoop(BasicBlock *b) {
-  //isn't this exciting
-  return ContinueBlock;
-}
-
-GENERIC_TRANSLATION(NOOP, doNoop(block))
-
 template<int width>
 static Value * doAddVV(NativeInstPtr ip, BasicBlock *&b, Value *lhs,
                        Value *rhs) {

--- a/tools/mcsema_disass/ida/get_cfg.py
+++ b/tools/mcsema_disass/ida/get_cfg.py
@@ -1263,7 +1263,7 @@ def processStruct(ea, size):
     for i in xrange(num_iters):
         # parse a single struct
         start_ea = ea + (i * struct_size)
-        worked, ptrs, ptrsize = parseSingleStruct(ea, idastruct)
+        worked, ptrs, ptrsize = parseSingleStruct(start_ea, idastruct)
         if worked:
             all_ptrs.update(ptrs)
 


### PR DESCRIPTION
* Fix MOV*ao* to not be backwards, and to use external references
* Iterate over strutures in get_cfg.py instead of repeating the same member
* Remove useless NOP in ADD.cpp