### PR TITLE
Fix sub ordering

### DIFF
--- a/mcsema/Arch/X86/Semantics/Misc.cpp
+++ b/mcsema/Arch/X86/Semantics/Misc.cpp
@@ -705,10 +705,12 @@ static InstTransResult doBTSmr(NativeInstPtr ip, llvm::BasicBlock *&b,
   auto ptr = ADDR_TO_POINTER<width>(b, base);
   auto gep = llvm::GetElementPtrInst::CreateInBounds(ptr, {word}, "", b);
   auto val = M_READ<width>(ip, b, gep);
+
   SHR_SET_FLAG_V<width, 1>(b, val, llvm::X86::CF, bit);
 
-  auto bit_to_set = llvm::BinaryOperator::CreateLShr(
+  auto bit_to_set = llvm::BinaryOperator::CreateShl(
       CONST_V<width>(b, 1), bit, "", b);
+
   auto new_val = llvm::BinaryOperator::CreateOr(val, bit_to_set, "", b);
   M_WRITE<width>(ip, b, gep, new_val);
 

--- a/mcsema/Arch/X86/Semantics/SUB.cpp
+++ b/mcsema/Arch/X86/Semantics/SUB.cpp
@@ -323,8 +323,9 @@ GENERIC_TRANSLATION(SUB16ri8, doSubRI<16>(ip, block, OP(0), OP(1), OP(2)))
 GENERIC_TRANSLATION_REF(SUB16rm,
                         doSubRM<16>(ip, block, ADDR_NOREF(2), OP(0), OP(1)),
                         doSubRM<16>(ip, block, MEM_REFERENCE(2), OP(0), OP(1)))
-GENERIC_TRANSLATION(SUB16rr, doSubRR<16>(ip, block, OP(1), OP(2), OP(0)))
-GENERIC_TRANSLATION(SUB16rr_REV, doSubRR<16>(ip, block, OP(1), OP(2), OP(0)))
+
+GENERIC_TRANSLATION(SUB16rr, doSubRR<16>(ip, block, OP(0), OP(1), OP(2)))
+GENERIC_TRANSLATION(SUB16rr_REV, doSubRR<16>(ip, block, OP(0), OP(1), OP(2)))
 GENERIC_TRANSLATION_REF(
     SUB32i32,
     doSubRI<32>(ip, block, llvm::MCOperand::createReg(llvm::X86::EAX), llvm::MCOperand::createReg(llvm::X86::EAX), OP(0)),
@@ -387,8 +388,8 @@ GENERIC_TRANSLATION(SUB8ri, doSubRI<8>(ip, block, OP(0), OP(1), OP(2)))
 GENERIC_TRANSLATION_REF(SUB8rm,
                         doSubRM<8>(ip, block, ADDR_NOREF(2), OP(0), OP(1)),
                         doSubRM<8>(ip, block, MEM_REFERENCE(2), OP(0), OP(1)))
-GENERIC_TRANSLATION(SUB8rr, doSubRR<8>(ip, block, OP(1), OP(2), OP(0)))
-GENERIC_TRANSLATION(SUB8rr_REV, doSubRR<8>(ip, block, OP(1), OP(2), OP(0)))
+GENERIC_TRANSLATION(SUB8rr, doSubRR<8>(ip, block, OP(0), OP(1), OP(2)))
+GENERIC_TRANSLATION(SUB8rr_REV, doSubRR<8>(ip, block, OP(0), OP(1), OP(2)))
 GENERIC_TRANSLATION(
     SBB16i16,
     doSbbRI<16>(ip, block, llvm::MCOperand::createReg(llvm::X86::AX), OP(0), llvm::MCOperand::createReg(llvm::X86::AX)))


### PR DESCRIPTION
GENERIC_TRANSLATION(SUB16rr, doSubRR<16>(ip, block, OP(0), OP(1), OP(2)))
GENERIC_TRANSLATION(SUB16rr_REV, doSubRR<16>(ip, block, OP(0), OP(1), OP(2)))

GENERIC_TRANSLATION(SUB8rr, doSubRR<8>(ip, block, OP(0), OP(1), OP(2)))
GENERIC_TRANSLATION(SUB8rr_REV, doSubRR<8>(ip, block, OP(0), OP(1), OP(2)))

Both of the above had reversed parameters, so it was OP(1), OP(2), OP(0) when it should be OP(0), OP(1), OP(2)

There are others following the same OP format, and I'm not sure all are wrong so I didn't mess with the others.  But, here's a list from SUB.cpp if you're interested: 

GENERIC_TRANSLATION(SBB16ri, doSbbRI<16>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB16ri8, doSbbRI<16>(ip, block, OP(1), OP(2), OP(0)))
                        doSbbRM<16>(ip, block, OP(1), ADDR_NOREF(2), OP(0)),
                        doSbbRM<16>(ip, block, OP(1), MEM_REFERENCE(2), OP(0)))
GENERIC_TRANSLATION(SBB16rr, doSbbRR<16>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB16rr_REV, doSbbRR<16>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB32ri, doSbbRI<32>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB32ri8, doSbbRI<32>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB64ri8, doSbbRI<64>(ip, block, OP(1), OP(2), OP(0)))
                        doSbbRM<32>(ip, block, OP(1), ADDR_NOREF(2), OP(0)),
                        doSbbRM<32>(ip, block, OP(1), MEM_REFERENCE(2), OP(0)))
GENERIC_TRANSLATION(SBB32rr, doSbbRR<32>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB32rr_REV, doSbbRR<32>(ip, block, OP(1), OP(2), OP(0)))
                        doSbbRM<64>(ip, block, OP(1), ADDR_NOREF(2), OP(0)),
                        doSbbRM<64>(ip, block, OP(1), MEM_REFERENCE(2), OP(0)))
GENERIC_TRANSLATION(SBB64rr, doSbbRR<64>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB64rr_REV, doSbbRR<64>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB8ri, doSbbRI<8>(ip, block, OP(1), OP(2), OP(0)))
                        doSbbRM<8>(ip, block, OP(1), ADDR_NOREF(2), OP(0)),
                        doSbbRM<8>(ip, block, OP(1), MEM_REFERENCE(2), OP(0)))
GENERIC_TRANSLATION(SBB8rr, doSbbRR<8>(ip, block, OP(1), OP(2), OP(0)))
GENERIC_TRANSLATION(SBB8rr_REV, doSbbRR<8>(ip, block, OP(1), OP(2), OP(0)))
