### PR TITLE
Sign-extend imm8 push operands to 64 bit on x86_64.

### DIFF
--- a/mcsema/Arch/X86/Semantics/Stack.cpp
+++ b/mcsema/Arch/X86/Semantics/Stack.cpp
@@ -485,12 +485,19 @@ static InstTransResult doPushI(NativeInstPtr ip, llvm::BasicBlock *&b,
   // in IA32
   llvm::Value *SExt_Val = OrigIMM;
 
-  // PUSHi8 is extended to operand size, which is 32
+  // PUSHi8 is extended to operand size, which is 32 or 64
   if (width == 8) {
+    if (ArchPointerSize(M) == Pointer32) {
     SExt_Val = new llvm::SExtInst(OrigIMM,
                                   llvm::Type::getInt32Ty(b->getContext()), "",
                                   b);
     doPushV<32>(ip, b, SExt_Val);
+    } else { //Pointer64
+      SExt_Val = new llvm::SExtInst(OrigIMM,
+                                  llvm::Type::getInt64Ty(b->getContext()), "",
+                                  b);
+    doPushV<64>(ip, b, SExt_Val);
+    }
   } else {
     if (width == 32 && ip->has_ext_call_target()) {
       std::string target = ip->get_ext_call_target()->getSymbolName();


### PR DESCRIPTION
On x86_64, imm8 pushes lead to 64bit sign extension of the operand. Hence, instructions such as

6a 00       push 0x0

decrement rsp by 8. However, prior to this fix, mcsema created a 4 byte decrement, leading to stack corruption. Consequently, when lifting the ls.cfg example and compiling back, the resulting binary crashes when invoked with the --version parameter.