### PR TITLE
Explicit args [WIP]

### DIFF
--- a/mcsema/Arch/X86/Runtime/CallingConv.cpp
+++ b/mcsema/Arch/X86/Runtime/CallingConv.cpp
@@ -10,7 +10,7 @@ namespace mcsema {
 addr_t __mcsema_cdecl_arg_0(Memory *, State *) {
   // stack args
   // memory[rsp]
-  return State->gpr->rsp;
+  return remill::State->gpr->rsp;
 }
 
 addr_t __mcsema_cdecl_arg_1(Memory *, State *) {
@@ -163,6 +163,23 @@ addr_t __mcsema_cdecl_arg_38(Memory *, State *) {
 
 addr_t __mcsema_cdecl_arg_39(Memory *, State *) {
   return State->gpr->rsp + 39*4; //XXX(car) sizeof
+}
+
+// fastcall
+addr_t __mcsema_argument_fastcc_1(Memory *, State *) {
+  return State->gpr->rcx;
+}
+
+addr_t __mcsema_argument_fastcc_2(Memory *, State *) {
+  return State->gpr->rdx;
+}
+
+addr_t __mcsema_argument_fastcc_3(Memory *, State *) {
+  return State->gpr->rsp; // deref?
+}
+
+addr_t __mcsema_argument_fastcc_4(Memory *, State *) {
+  return State->gpr->rsp+4; // deref; fix 4
 }
 
 } // namespace mcsema

--- a/mcsema/Arch/X86/Runtime/CallingConv.cpp
+++ b/mcsema/Arch/X86/Runtime/CallingConv.cpp
@@ -1,0 +1,168 @@
+#define HAS_FEATURE_AVX 1
+#define HAS_FEATURE_AVX512 0
+#define ADDRESS_SIZE_BITS 64
+
+#include "remill/Arch/X86/Runtime/State.h"
+
+namespace mcsema {
+
+// TODO(car): generate as needed somehow
+addr_t __mcsema_cdecl_arg_0(Memory *, State *) {
+  // stack args
+  // memory[rsp]
+  return State->gpr->rsp;
+}
+
+addr_t __mcsema_cdecl_arg_1(Memory *, State *) {
+  return State->gpr->rsp + 1*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_2(Memory *, State *) {
+  return State->gpr->rsp + 2*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_3(Memory *, State *) {
+  return State->gpr->rsp + 3*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_4(Memory *, State *) {
+  return State->gpr->rsp + 4*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_5(Memory *, State *) {
+  return State->gpr->rsp + 5*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_6(Memory *, State *) {
+  return State->gpr->rsp + 6*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_7(Memory *, State *) {
+  return State->gpr->rsp + 7*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_8(Memory *, State *) {
+  return State->gpr->rsp + 8*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_9(Memory *, State *) {
+  return State->gpr->rsp + 9*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_10(Memory *, State *) {
+  return State->gpr->rsp + 10*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_11(Memory *, State *) {
+  return State->gpr->rsp + 11*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_12(Memory *, State *) {
+  return State->gpr->rsp + 12*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_13(Memory *, State *) {
+  return State->gpr->rsp + 13*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_14(Memory *, State *) {
+  return State->gpr->rsp + 14*14; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_15(Memory *, State *) {
+  return State->gpr->rsp + 15*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_16(Memory *, State *) {
+  return State->gpr->rsp + 16*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_17(Memory *, State *) {
+  return State->gpr->rsp + 17*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_18(Memory *, State *) {
+  return State->gpr->rsp + 18*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_19(Memory *, State *) {
+  return State->gpr->rsp + 19*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_20(Memory *, State *) {
+  return State->gpr->rsp + 20*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_21(Memory *, State *) {
+  return State->gpr->rsp + 21*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_22(Memory *, State *) {
+  return State->gpr->rsp + 22*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_23(Memory *, State *) {
+  return State->gpr->rsp + 23*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_24(Memory *, State *) {
+  return State->gpr->rsp + 24*24; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_25(Memory *, State *) {
+  return State->gpr->rsp + 25*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_26(Memory *, State *) {
+  return State->gpr->rsp + 26*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_27(Memory *, State *) {
+  return State->gpr->rsp + 27*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_28(Memory *, State *) {
+  return State->gpr->rsp + 28*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_29(Memory *, State *) {
+  return State->gpr->rsp + 29*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_31(Memory *, State *) {
+  return State->gpr->rsp + 31*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_32(Memory *, State *) {
+  return State->gpr->rsp + 32*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_33(Memory *, State *) {
+  return State->gpr->rsp + 33*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_34(Memory *, State *) {
+  return State->gpr->rsp + 34*34; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_35(Memory *, State *) {
+  return State->gpr->rsp + 35*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_36(Memory *, State *) {
+  return State->gpr->rsp + 36*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_37(Memory *, State *) {
+  return State->gpr->rsp + 37*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_38(Memory *, State *) {
+  return State->gpr->rsp + 38*4; //XXX(car) sizeof
+}
+
+addr_t __mcsema_cdecl_arg_39(Memory *, State *) {
+  return State->gpr->rsp + 39*4; //XXX(car) sizeof
+}
+
+} // namespace mcsema

--- a/mcsema/Arch/X86/Runtime/CallingConv.h
+++ b/mcsema/Arch/X86/Runtime/CallingConv.h
@@ -1,0 +1,9 @@
+#include "remill/Arch/X86/Runtime/State.h"
+
+namespace mcsema {
+
+addr_t __mcsema_argument_cdecl_1(Memory *, State *);
+addr_t __mcsema_argument_cdecl_2(Memory *, State *);
+addr_t __mcsema_argument_cdecl_3(Memory *, State *);
+
+} // namespace mcsema

--- a/mcsema/Arch/X86/Runtime/CallingConv.h
+++ b/mcsema/Arch/X86/Runtime/CallingConv.h
@@ -5,5 +5,47 @@ namespace mcsema {
 addr_t __mcsema_argument_cdecl_1(Memory *, State *);
 addr_t __mcsema_argument_cdecl_2(Memory *, State *);
 addr_t __mcsema_argument_cdecl_3(Memory *, State *);
+addr_t __mcsema_argument_cdecl_4(Memory *, State *);
+addr_t __mcsema_argument_cdecl_5(Memory *, State *);
+addr_t __mcsema_argument_cdecl_6(Memory *, State *);
+addr_t __mcsema_argument_cdecl_7(Memory *, State *);
+addr_t __mcsema_argument_cdecl_8(Memory *, State *);
+addr_t __mcsema_argument_cdecl_9(Memory *, State *);
+addr_t __mcsema_argument_cdecl_10(Memory *, State *);
+addr_t __mcsema_argument_cdecl_11(Memory *, State *);
+addr_t __mcsema_argument_cdecl_12(Memory *, State *);
+addr_t __mcsema_argument_cdecl_13(Memory *, State *);
+addr_t __mcsema_argument_cdecl_14(Memory *, State *);
+addr_t __mcsema_argument_cdecl_15(Memory *, State *);
+addr_t __mcsema_argument_cdecl_16(Memory *, State *);
+addr_t __mcsema_argument_cdecl_17(Memory *, State *);
+addr_t __mcsema_argument_cdecl_18(Memory *, State *);
+addr_t __mcsema_argument_cdecl_19(Memory *, State *);
+addr_t __mcsema_argument_cdecl_20(Memory *, State *);
+addr_t __mcsema_argument_cdecl_21(Memory *, State *);
+addr_t __mcsema_argument_cdecl_22(Memory *, State *);
+addr_t __mcsema_argument_cdecl_23(Memory *, State *);
+addr_t __mcsema_argument_cdecl_24(Memory *, State *);
+addr_t __mcsema_argument_cdecl_25(Memory *, State *);
+addr_t __mcsema_argument_cdecl_26(Memory *, State *);
+addr_t __mcsema_argument_cdecl_27(Memory *, State *);
+addr_t __mcsema_argument_cdecl_28(Memory *, State *);
+addr_t __mcsema_argument_cdecl_29(Memory *, State *);
+addr_t __mcsema_argument_cdecl_30(Memory *, State *);
+addr_t __mcsema_argument_cdecl_31(Memory *, State *);
+addr_t __mcsema_argument_cdecl_32(Memory *, State *);
+addr_t __mcsema_argument_cdecl_33(Memory *, State *);
+addr_t __mcsema_argument_cdecl_34(Memory *, State *);
+addr_t __mcsema_argument_cdecl_35(Memory *, State *);
+addr_t __mcsema_argument_cdecl_36(Memory *, State *);
+addr_t __mcsema_argument_cdecl_37(Memory *, State *);
+addr_t __mcsema_argument_cdecl_38(Memory *, State *);
+addr_t __mcsema_argument_cdecl_39(Memory *, State *);
+addr_t __mcsema_argument_cdecl_40(Memory *, State *);
+
+addr_t __mcsema_argument_fastcc_1(Memory *, State *);
+addr_t __mcsema_argument_fastcc_2(Memory *, State *);
+addr_t __mcsema_argument_fastcc_3(Memory *, State *);
+addr_t __mcsema_argument_fastcc_4(Memory *, State *);
 
 } // namespace mcsema

--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -190,7 +190,6 @@ static void AddArgNForCConv(llvm::IRBuilder<> *ir, int64_t n, llvm::CallingConv:
         cc_str = "mcsemacall";
         break;
       default:
-        LOG(WARNING) << "trying to get calling conv number " << cc << "\n";
         cc_str = "cdecl"; // XXX(car): just for testing; fix
         break;
     }
@@ -208,8 +207,8 @@ static void AddArgNForCConv(llvm::IRBuilder<> *ir, int64_t n, llvm::CallingConv:
     args[1] = remill::NthArgument(callback_func, remill::kStatePointerArgNum);
     auto ret = ir->CreateCall(f, args);
 
-    ir->CreateStore(ret, remill::NthArgument(callback_func, remill::kMemoryPointerArgNum)); // XXX progress this according to cconv?
-    
+    ir->CreateStore(ret, remill::NthArgument(callback_func, remill::kMemoryPointerArgNum)); // XXX progress this according to cconv + n
+
     return;
 }
 
@@ -230,6 +229,7 @@ static llvm::Function *GetCallbackExplicitArgs(
     }
     //TODO(car): set calling conv appropriately
     callback_func->setCallingConv(llvm::CallingConv::C);
+    ir.CreateRetVoid(); //XXX(car): just for testing
     return callback_func;
 }
 

--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -184,7 +184,7 @@ static llvm::Instruction *GetArgNForCConv(llvm::IRBuilder<> *ir, int64_t n, llvm
         cc_str = "stdcall";
         break;
       case (NativeExternalFunction::FastCall):
-        cc_str = "fastcall";
+        cc_str = "fastcc";
         break;
       case (NativeExternalFunction::McsemaCall):
         cc_str = "mcsemacall";

--- a/mcsema/BC/External.cpp
+++ b/mcsema/BC/External.cpp
@@ -31,9 +31,13 @@
 namespace mcsema {
 namespace {
 
-// TODO(pag): Use the info from the CFG proto.
 static void DeclareExternal(const NativeExternalFunction *cfg_func) {
+  //get(Type *Result, ArrayRef<Type*> Params, bool isVarArg)
+  //std::vector<llvm::Type *> params;
+  //for(int i = 0; i < cfg_func->num_args; i++)
+  //  params.push_back(llvm::Type::getVoidTy(*gContext));
   auto func_type = llvm::FunctionType::get(
+      //llvm::Type::getVoidTy(*gContext), params, true);
       llvm::Type::getVoidTy(*gContext), true);
 
   auto func = llvm::Function::Create(
@@ -43,6 +47,8 @@ static void DeclareExternal(const NativeExternalFunction *cfg_func) {
   if (cfg_func->is_weak) {
     func->setLinkage(llvm::GlobalValue::ExternalWeakLinkage);
   }
+
+  //func->setCallingConv(llvm::CallingConv::McSemaCall);
 }
 
 }  // namespace

--- a/mcsema/BC/External.h
+++ b/mcsema/BC/External.h
@@ -17,6 +17,15 @@
 #ifndef MCSEMA_BC_EXTERNAL_H_
 #define MCSEMA_BC_EXTERNAL_H_
 
+namespace llvm {
+namespace CallingConv {
+  using ID = unsigned;
+  enum {
+    McSemaCall = 144
+  };
+} // namespace CallingConv
+} // namespace llvm
+
 namespace mcsema {
 struct NativeModule;
 

--- a/mcsema/BC/Function.cpp
+++ b/mcsema/BC/Function.cpp
@@ -117,7 +117,10 @@ static llvm::Value *AddSubFuncCall(llvm::BasicBlock *block,
   args[remill::kMemoryPointerArgNum] = remill::LoadMemoryPointer(block);
   args[remill::kStatePointerArgNum] = remill::LoadStatePointer(block);
   args[remill::kPCArgNum] = remill::LoadProgramCounter(block);
-  return llvm::CallInst::Create(sub, args, "", block);
+  auto call = llvm::CallInst::Create(sub, args, "", block);
+  // ensure we have compatible calling conventions
+  call->setCallingConv(sub->getCallingConv());
+  return call;
 }
 
 // Add a call to another function, and then update the memory pointer with the

--- a/mcsema/CFG/CFG.cpp
+++ b/mcsema/CFG/CFG.cpp
@@ -516,6 +516,9 @@ NativeModule *ReadProtoBuf(const std::string &file_name,
     if(cfg_extern_func.has_argument_count()) {
       func->num_args = cfg_extern_func.argument_count();
     }
+    else { // no argc recorded
+      func->num_args = 0; // XXX ???
+    }
     if(cfg_extern_func.has_cc()) {
       switch(cfg_extern_func.cc()) {
       case ExternalFunction_CallingConvention_CalleeCleanup:
@@ -532,9 +535,12 @@ NativeModule *ReadProtoBuf(const std::string &file_name,
         break;
       default:
         // unknown calling conv...
-        //func->cc = llvm::CallingConv::Unknown;
+        func->cc = NativeExternalFunction::calling_conv::Unknown;
         break;
       }
+    }
+    else { // no cc recorded
+      func->cc = NativeExternalFunction::calling_conv::Unknown;
     }
 
     CHECK(!func->name.empty())

--- a/mcsema/CFG/CFG.cpp
+++ b/mcsema/CFG/CFG.cpp
@@ -30,6 +30,7 @@
 #pragma clang diagnostic pop
 
 #include "mcsema/CFG/CFG.h"
+#include "mcsema/BC/External.h"
 
 namespace mcsema {
 namespace {
@@ -512,6 +513,29 @@ NativeModule *ReadProtoBuf(const std::string &file_name,
     func->is_external = true;
     func->is_weak = cfg_extern_func.is_weak();
     func->lifted_name = ExternalFuncName(cfg_extern_func);
+    if(cfg_extern_func.has_argument_count()) {
+      func->num_args = cfg_extern_func.argument_count();
+    }
+    if(cfg_extern_func.has_cc()) {
+      switch(cfg_extern_func.cc()) {
+      case ExternalFunction_CallingConvention_CalleeCleanup:
+        func->cc = NativeExternalFunction::calling_conv::CalleeCleanup;
+        break;
+      case ExternalFunction_CallingConvention_CallerCleanup:
+        func->cc = NativeExternalFunction::calling_conv::CallerCleanup;
+        break;
+      case ExternalFunction_CallingConvention_FastCall:
+        func->cc = NativeExternalFunction::calling_conv::FastCall;
+        break;
+      case ExternalFunction_CallingConvention_McsemaCall:
+        func->cc = NativeExternalFunction::calling_conv::McsemaCall;
+        break;
+      default:
+        // unknown calling conv...
+        //func->cc = llvm::CallingConv::Unknown;
+        break;
+      }
+    }
 
     CHECK(!func->name.empty())
         << "External function at " << std::hex << func->ea << " has no name.";

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -89,6 +89,14 @@ struct NativeFunction : public NativeObject {
 struct NativeExternalFunction : public NativeFunction {
  public:
   bool is_weak;
+  int64_t num_args;
+  enum calling_conv {
+    CallerCleanup,
+    CalleeCleanup,
+    FastCall,
+    McsemaCall
+  };
+  calling_conv cc;
 };
 
 // Global variable defined inside of the lifted binary.

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -91,6 +91,7 @@ struct NativeExternalFunction : public NativeFunction {
   bool is_weak;
   int64_t num_args;
   enum calling_conv {
+    Unknown,
     CallerCleanup,
     CalleeCleanup,
     FastCall,

--- a/tools/mcsema_disass/ida/refs.py
+++ b/tools/mcsema_disass/ida/refs.py
@@ -171,7 +171,9 @@ def _try_get_arm_ref_addr(inst, op, op_val, all_refs):
   global _BAD_ARM_REF_OFF
 
   if op.type not in (idc.o_imm, idc.o_displ):
-    return _BAD_ARM_REF_OFF
+    # This is a reference type that the other ref tracking code
+    # can handle, return defaults
+    return op_val, 0
 
   op_str = idc.GetOpnd(inst.ea, op.n)
 
@@ -207,6 +209,12 @@ def _get_ref_candidate(inst, op, all_refs):
   else:
     return None
 
+
+  #TODO(artem): we should have a class that has ref heuristics
+  # and put ARM related refs in the ARM class, and X86 in the x86 class
+  #
+  # that will avoid these awkward `if IS_ARM` and the comments
+  # about x86 / amd64 stuff
   if IS_ARM:
     addr_val, mask = _try_get_arm_ref_addr(inst, op, addr_val, all_refs)
   
@@ -277,14 +285,23 @@ def get_all_references_from(ea):
   for ref_ea in idautils.DataRefsFrom(ea):
     if not is_invalid_ea(ref_ea):
       all_refs.add(ref_ea)
+    else:
+      #DEBUG("Found an invalid ref from {:x} to {:x}".format(ea, ref_ea))
+      pass
 
   for ref_ea in idautils.CodeRefsFrom(ea, 0):
     if not is_invalid_ea(ref_ea):
       all_refs.add(ref_ea)
+    else:
+      #DEBUG("We found an invalid ref from {:x} to {:x}".format(ea, ref_ea))
+      pass
 
   for ref_ea in idautils.CodeRefsFrom(ea, 1):
     if not is_invalid_ea(ref_ea):
       all_refs.add(ref_ea)
+    else:
+      #DEBUG("We found an invalid ref from {:x} to {:x}".format(ea, ref_ea))
+      pass
 
   return all_refs
 


### PR DESCRIPTION
Bitcode generated with --explicit-args argument now has, for external function calls, calls to retrieve each argument according to calling convention. Still WIP.