### PR TITLE
Add experimental CFG recovery frontend based on Dyninst

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@
 project(mcsema)
 cmake_minimum_required (VERSION 3.2)
 
+set(CMAKE_CXX_STANDARD 14)
+add_compile_options(-std=c++14)
+
 set(MCSEMA_SOURCE_DIR "${PROJECT_SOURCE_DIR}")
 
 # warnings and compiler settings
@@ -95,6 +98,13 @@ install(
   TARGETS ${MCSEMA_LIFT}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib)
+
+if(DEFINED ENV{BUILD_MCSEMA_DYNINST_DISASS})
+  if($ENV{BUILD_MCSEMA_DYNINST_DISASS} EQUAL 1)
+    add_custom_target(generate-protobuf-files DEPENDS ${PROJECT_PROTOBUFSOURCEFILES})
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/tools/mcsema_disass/dyninst/)
+  endif()
+endif()
   
 install(CODE
     "execute_process(COMMAND python ${PROJECT_SOURCE_DIR}/tools/setup.py install -f --prefix=${CMAKE_INSTALL_PREFIX})")

--- a/tools/mcsema_disass/dyninst/ArgParser.cc
+++ b/tools/mcsema_disass/dyninst/ArgParser.cc
@@ -1,0 +1,134 @@
+#include "ArgParser.hpp"
+#include <cstdlib>
+#include <iostream>
+
+ArgParser::ArgParser (int argc, char **argv)
+    : m_appName (argv [0]), m_args (),
+      m_inputFiles (), m_stdDefFiles (),
+      m_dumpCfg (false), m_prettyPrintCfg (false),
+      m_outputFiles (), m_addExtSyms ()
+{
+    for (int i = 1; i < argc; ++i)
+        m_args.push_back ({ argv [i] });
+
+    if (m_args.size () == 1)
+    {
+        if ((m_args.front () == "--help" ) || (m_args.back () == "-h"))
+        {
+            printHelp ();
+            std::exit (0);
+        }
+    }
+
+    while (!m_args.empty ())
+    {
+        auto curArg = m_args.front ();
+
+        if (curArg.front () == '-')
+        {
+            if ((curArg == "-h") || (curArg == "--help"))
+                throw std::runtime_error { "-h and --help may not be used in conjunction with other arguments" };
+            else if (curArg == "--std-defs")
+            {
+                m_args.pop_front ();
+
+                if (m_args.empty ())
+                    throw std::runtime_error { "--std-defs option needs an argument" };
+
+                m_stdDefFiles.push_back (m_args.front ());
+            }
+            else if (curArg == "--dump-cfg")
+            {
+                m_dumpCfg = true;
+            }
+            else if (curArg == "--pretty-print")
+            {
+                m_prettyPrintCfg = true;
+            }
+            else if (curArg == "--no-pretty-print")
+            {
+                m_prettyPrintCfg = false;
+            }
+            else if (curArg == "-o")
+            {
+                m_args.pop_front ();
+
+                if (m_args.empty ())
+                    throw std::runtime_error { "-o option needs an argument" };
+
+                m_outputFiles.push_back (m_args.front ());
+            }
+            else if (curArg == "--add-ext-sym")
+            {
+                m_args.pop_front ();
+
+                if (m_args.empty ())
+                    throw std::runtime_error { "--add-ext-sym option needs an argument" };
+
+                m_addExtSyms.push_back (m_args.front ());
+            }
+            else
+            {
+                std::cerr << "unrecognized command line option: \"" << curArg << "\"" << std::endl;
+                std::cerr << "use `" << m_appName << " --help` for a list of available options" << std::endl;
+                throw std::runtime_error { "unrecognized command line option" };
+            }
+        }
+        else
+            m_inputFiles.push_back (curArg);
+
+        m_args.pop_front ();
+    }
+}
+
+void ArgParser::printHelp () const
+{
+    std::cout
+        << "Available options:" << std::endl
+        << std::endl
+        << "  -h, --help: prints this help text" << std::endl
+        << "  --std-defs <FILE>: read external symbol definitions from <FILE>" << std::endl
+        << "                     (may be used multiple times)" << std::endl
+        << "  --dump-cfg: print the created CFG file to stdout in a human-readable format" << std::endl
+        << "  --[no-]pretty-print: pretty-print the CFG file (default: on)" << std::endl
+        << "                       (only makes sense with --dump-cfg)" << std::endl
+        << "  -o <FILE>: output resulting CFG into <FILE> (default: none)" << std::endl
+        << "  --add-ext-sym <DESCRIPTION>: parse <DESCRIPTION> as if it were a line in a" << std::endl
+        << "                               symbol definitions file" << std::endl
+        ;
+}
+
+const std::string& ArgParser::getAppName () const
+{
+    return m_appName;
+}
+
+const std::vector<std::string>& ArgParser::getInputFiles () const
+{
+    return m_inputFiles;
+}
+
+const std::vector<std::string>& ArgParser::getStdDefFiles () const
+{
+    return m_stdDefFiles;
+}
+
+const bool ArgParser::getDumpCfg () const
+{
+    return m_dumpCfg;
+}
+
+const bool ArgParser::getPrettyPrintCfg () const
+{
+    return m_prettyPrintCfg;
+}
+
+const std::vector<std::string>& ArgParser::getOutputFiles () const
+{
+    return m_outputFiles;
+}
+
+const std::vector<std::string>& ArgParser::getAddExtSyms () const
+{
+    return m_addExtSyms;
+}

--- a/tools/mcsema_disass/dyninst/ArgParser.hpp
+++ b/tools/mcsema_disass/dyninst/ArgParser.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <string>
+#include <deque>
+#include <vector>
+
+class ArgParser
+{
+public:
+    ArgParser () = delete;
+    ArgParser (int argc, char **argv);
+
+    void printHelp () const;
+
+    const std::string& getAppName () const;
+    const std::vector<std::string>& getInputFiles () const;
+    const std::vector<std::string>& getStdDefFiles () const;
+    const bool getDumpCfg () const;
+    const bool getPrettyPrintCfg () const;
+    const std::vector<std::string>& getOutputFiles () const;
+    const std::vector<std::string>& getAddExtSyms () const;
+
+private:
+    std::string m_appName;
+    std::deque<std::string> m_args;
+
+    std::vector<std::string> m_inputFiles;
+    std::vector<std::string> m_stdDefFiles;
+    bool m_dumpCfg;
+    bool m_prettyPrintCfg;
+    std::vector<std::string> m_outputFiles;
+    std::vector<std::string> m_addExtSyms;
+};

--- a/tools/mcsema_disass/dyninst/CFGWriter.cc
+++ b/tools/mcsema_disass/dyninst/CFGWriter.cc
@@ -1,0 +1,497 @@
+#include "CFGWriter.hpp"
+#include <Dereference.h>
+#include <Function.h>
+#include <Instruction.h>
+#include <InstructionAST.h>
+#include <InstructionCategories.h>
+#include <sstream>
+
+using namespace Dyninst;
+
+CFGWriter::CFGWriter (mcsema::Module& m, const std::string& moduleName,
+                      SymtabAPI::Symtab& symtab,
+                      ParseAPI::CodeObject& codeObj,
+                      const ExternalFunctionManager& extFuncMgr)
+    : m_module (m), m_moduleName (moduleName), m_symtab (symtab),
+      m_codeObj (codeObj), m_extFuncMgr (extFuncMgr), m_funcMap (),
+      m_skipFuncs (), m_sectionMgr (), m_relocations ()
+{
+    // Populate m_funcMap
+
+    std::vector<SymtabAPI::Function *> functions;
+    m_symtab.getAllFunctions (functions);
+
+    for (auto func : functions)
+        m_funcMap [func->getOffset ()] = *(func->mangled_names_begin ());
+
+    // Populate m_skipFuncs with some functions known to cause problems
+
+    m_skipFuncs = { "register_tm_clones", "deregister_tm_clones", "__libc_csu_init",
+                    "frame_dummy", "_init", "_start", "__do_global_dtors_aux",
+                    "__libc_csu_fini", "_fini", "__libc_start_main" };
+
+    // Populate m_sectionMgr with the data from symtab
+
+    std::vector<SymtabAPI::Region *> regions;
+    symtab.getAllRegions (regions);
+
+    for (auto reg : regions)
+        m_sectionMgr.addRegion (reg);
+
+    // Fill in m_relocations
+
+    for (auto reg : regions)
+    {
+        if (reg->getRegionName () == ".text")
+            m_relocations = reg->getRelocations ();
+    }
+}
+
+void CFGWriter::skipFunction (const std::string& name)
+{
+    m_skipFuncs.insert (name);
+}
+
+void CFGWriter::write ()
+{
+    writeInternalFunctions ();
+    writeExternalFunctions ();
+    writeInternalData ();
+    m_module.set_name (m_moduleName);
+}
+
+bool CFGWriter::shouldSkipFunction (const std::string& name) const
+{
+    return m_skipFuncs.find (name) != m_skipFuncs.end ();
+}
+
+void CFGWriter::writeInternalFunctions ()
+{
+    for (ParseAPI::Function *func : m_codeObj.funcs ())
+    {
+        if (shouldSkipFunction (func->name ()))
+            continue;
+        else if (isExternal (func->entry ()->start ()))
+            continue;
+
+        // Add an entry in the protocol buffer
+
+        auto cfgInternalFunc = m_module.add_funcs ();
+
+        // Set the entry address
+
+        ParseAPI::Block *entryBlock = func->entry ();
+        cfgInternalFunc->set_ea (entryBlock->start ());
+
+        cfgInternalFunc->set_is_entrypoint (true); /* TODO */
+
+        // Write blocks
+
+        for (ParseAPI::Block *block : func->blocks ())
+            writeBlock (block, func, cfgInternalFunc);
+
+        if (m_funcMap.find (func->addr ()) != m_funcMap.end ())
+            cfgInternalFunc->set_name (m_funcMap [func->addr ()]);
+    }
+}
+
+void CFGWriter::writeBlock (ParseAPI::Block *block, ParseAPI::Function *func,
+                            mcsema::Function *cfgInternalFunc)
+{
+    // Add a new block to the protocol buffer and set its base address
+
+    mcsema::Block *cfgBlock = cfgInternalFunc->add_blocks ();
+    cfgBlock->set_ea (block->start ());
+
+    // Set outgoing edges
+
+    for (auto edge : block->targets ())
+    {
+        // Is this block part of the current function?
+
+        bool found = false;
+
+        for (auto bl : func->blocks ())
+        {
+            if (bl->start () == edge->trg ()->start ())
+            {
+                found = true;
+                break;
+            }
+        }
+
+        if ((!found) || (edge->trg ()->start () == -1))
+            continue;
+
+        // Handle recursive calls
+
+        found = false;
+
+        if (edge->trg ()->start () == func->entry ()->start ())
+        {
+            for (auto callEdge : func->callEdges ())
+            {
+                if ((callEdge->src ()->start () == block->start ())
+                    && (callEdge->trg ()->start () == func->entry ()->start ()))
+                {
+                    // Looks like a recursive call, so no block_follows edge here
+                    found = true;
+                    break;
+                }
+            }
+        }
+
+        if (!found)
+            cfgBlock->add_successor_eas (edge->trg ()->start ());
+    }
+
+    // Write instructions
+
+    std::map<Offset, InstructionAPI::Instruction::Ptr> instructions;
+    block->getInsns (instructions);
+
+    // This variable "simulates" the instruction pointer
+    Address ip = block->start ();
+
+    for (auto p : instructions)
+    {
+        InstructionAPI::Instruction *instruction = p.second.get ();
+
+        writeInstruction (instruction, ip, cfgBlock);
+        ip += instruction->size ();
+    }
+}
+
+void CFGWriter::writeInstruction (InstructionAPI::Instruction *instruction,
+                                  Address addr, mcsema::Block *cfgBlock)
+{
+    // Add a new instruction to the protocol buffer
+
+    mcsema::Instruction *cfgInstruction = cfgBlock->add_instructions ();
+
+    // Set the raw instruction bytes
+
+    std::string instBytes;
+
+    for (int offset = 0; offset < instruction->size (); ++offset)
+        instBytes += instruction->rawByte (offset);
+
+    cfgInstruction->set_bytes (instBytes);
+
+    // Set the instruction address
+
+    cfgInstruction->set_ea (addr);
+
+    cfgInstruction->set_local_noreturn (false); // TODO
+
+    // Handle the instruction's operands
+
+    std::vector<InstructionAPI::Operand> operands;
+    instruction->getOperands (operands);
+
+    if (instruction->getCategory () == InstructionAPI::c_CallInsn)
+        handleCallInstruction (instruction, addr, cfgInstruction);
+    else
+        handleNonCallInstruction (instruction, addr, cfgInstruction);
+}
+
+void CFGWriter::handleCallInstruction (InstructionAPI::Instruction *instruction,
+                                       Address addr, mcsema::Instruction *cfgInstruction)
+{
+    Address target;
+
+    std::vector<InstructionAPI::Operand> operands;
+    instruction->getOperands (operands);
+
+    if (tryEval (operands [0].getValue ().get (), addr + 5, target))
+    {
+        target -= 5;
+
+        if (isExternal (target))
+        {
+            auto cfgCodeRef = cfgInstruction->add_xrefs ();
+            cfgCodeRef->set_target_type (mcsema::CodeReference::CodeTarget);
+            cfgCodeRef->set_operand_type (mcsema::CodeReference::ControlFlowOperand);
+            cfgCodeRef->set_location (mcsema::CodeReference::External);
+            cfgCodeRef->set_ea (target);
+            cfgCodeRef->set_name (getExternalName (target));
+
+            return;
+        }
+    }
+
+    if (m_relocations.size () > 0)
+    {
+        auto entry = *(m_relocations.begin ());
+        bool found = false;
+
+        for (auto ent : m_relocations)
+        {
+            if (ent.rel_addr () == (addr + 6))
+            {
+                entry = ent;
+                found = true;
+                break;
+            }
+        }
+
+        if (!((!found) || (found && (entry.getDynSym ()->getRegion () == NULL))))
+        {
+            Offset off = entry.getDynSym ()->getOffset ();
+
+            auto cfgCodeRef = cfgInstruction->add_xrefs ();
+            cfgCodeRef->set_target_type (mcsema::CodeReference::CodeTarget);
+            cfgCodeRef->set_operand_type (mcsema::CodeReference::ControlFlowOperand);
+            cfgCodeRef->set_location (mcsema::CodeReference::Internal);
+            cfgCodeRef->set_ea (off);
+
+            return;
+        }
+    }
+
+    if (tryEval (operands [0].getValue ().get (), addr + 5, target))
+    {
+        target -= 5;
+
+        auto cfgCodeRef = cfgInstruction->add_xrefs ();
+        cfgCodeRef->set_target_type (mcsema::CodeReference::CodeTarget);
+        cfgCodeRef->set_operand_type (mcsema::CodeReference::ControlFlowOperand);
+        cfgCodeRef->set_location (mcsema::CodeReference::Internal);
+        cfgCodeRef->set_ea (target);
+
+        return;
+    }
+
+    std::cerr << "error: unable to resolve call instruction at 0x"
+              << std::hex << addr << std::dec << std::endl;
+    throw std::runtime_error { "unresolved call instruction" };
+}
+
+void CFGWriter::handleNonCallInstruction (Dyninst::InstructionAPI::Instruction *instruction,
+                                          Address addr, mcsema::Instruction *cfgInstruction)
+{
+    std::vector<InstructionAPI::Operand> operands;
+    instruction->getOperands (operands);
+    addr += instruction->size ();
+
+    for (auto op : operands)
+    {
+        auto expr = op.getValue ();
+
+        if (auto imm = dynamic_cast<InstructionAPI::Immediate *> (expr.get ()))
+        {
+            Address a = imm->eval ().convert<Address> ();
+            if (m_sectionMgr.isData (a))
+            {
+                auto allSymsAtOffset = m_symtab.findSymbolByOffset (a);
+                bool isRef = false;
+                if (allSymsAtOffset.size () > 0)
+                {
+                    for (auto symbol : allSymsAtOffset)
+                    {
+                        if (symbol->getType () == SymtabAPI::Symbol::ST_OBJECT)
+                            isRef = true;
+                    }
+                }
+
+                if (a > 0x1000)
+                    isRef = true;
+
+                if (isRef)
+                {
+                    auto cfgCodeRef = cfgInstruction->add_xrefs ();
+                    cfgCodeRef->set_target_type (mcsema::CodeReference::DataTarget);
+                    cfgCodeRef->set_operand_type (mcsema::CodeReference::ImmediateOperand);
+                    cfgCodeRef->set_location (mcsema::CodeReference::Internal);
+                    cfgCodeRef->set_ea (a);
+
+                    if (m_relocations.size () > 0)
+                    {
+                        auto entry = *(m_relocations.begin ());
+                        for (auto ent : m_relocations)
+                        {
+                            if (ent.rel_addr () == (addr-instruction->size ())+1)
+                            {
+                                entry = ent;
+                                break;
+                            }
+                        }
+
+                        Offset off = entry.getDynSym ()->getOffset ();
+                        cfgCodeRef->set_ea (off + entry.addend ());
+                    }
+                }
+            }
+        }
+        else if (auto deref = dynamic_cast<InstructionAPI::Dereference *> (expr.get ()))
+        {
+            std::vector<InstructionAPI::InstructionAST::Ptr> children;
+            deref->getChildren (children);
+            auto expr = dynamic_cast<InstructionAPI::Expression *> (children [0].get ());
+            if (!expr) throw std::runtime_error { "expected expression" };
+
+            Address a;
+            if (tryEval (expr, addr, a))
+            {
+                auto cfgCodeRef = cfgInstruction->add_xrefs ();
+                cfgCodeRef->set_target_type (mcsema::CodeReference::DataTarget);
+                cfgCodeRef->set_operand_type (mcsema::CodeReference::MemoryOperand);
+                cfgCodeRef->set_location (mcsema::CodeReference::Internal);
+                cfgCodeRef->set_ea (a);
+            }
+        }
+    }
+}
+
+void CFGWriter::writeExternalFunctions ()
+{
+    for (const auto& func : m_extFuncMgr.getAllUsed ())
+    {
+        Address a;
+        bool found = false;
+
+        for (auto p : m_codeObj.cs ()->linkage ())
+        {
+            if (p.second == func.symbolName ())
+            {
+                found = true;
+                a = p.first;
+                break;
+            }
+        }
+
+        if (!found)
+            throw std::runtime_error { "unresolved external function call" };
+
+        auto cfgExtFunc = m_module.add_external_funcs ();
+
+        cfgExtFunc->set_name (func.symbolName ());
+        cfgExtFunc->set_ea (a);
+        cfgExtFunc->set_cc (func.cfgCallingConvention ());
+        cfgExtFunc->set_has_return (func.hasReturn ());
+        cfgExtFunc->set_no_return (func.noReturn ());
+        cfgExtFunc->set_argument_count (func.argumentCount ());
+        cfgExtFunc->set_is_weak (func.isWeak ());
+    }
+}
+
+void CFGWriter::writeInternalData ()
+{
+    auto dataRegions = m_sectionMgr.getDataRegions ();
+
+    for (auto region : dataRegions)
+    {
+        // Sanity check
+
+        if (region->getMemSize () <= 0)
+            continue;
+
+        auto cfgInternalData = m_module.add_segments ();
+
+        // Print raw data
+
+        std::string data;
+        int i = 0;
+
+        for (; i < region->getDiskSize (); ++i)
+            data += ((const char *) region->getPtrToRawData ()) [i];
+
+        for (; i < region->getMemSize (); ++i)
+            data += '\0';
+
+        // Print metadata
+
+        cfgInternalData->set_ea (region->getMemOffset ());
+        cfgInternalData->set_data (data);
+        cfgInternalData->set_read_only (region->getRegionPermissions () == SymtabAPI::Region::RP_R);
+        cfgInternalData->set_is_external (false);
+        cfgInternalData->set_name (region->getRegionName ());
+        cfgInternalData->set_is_exported (true); /* TODO */
+        cfgInternalData->set_is_thread_local (false); /* TODO */
+
+        if (region->getRegionName () == ".got.plt")
+        {
+            const auto& relocations = region->getRelocations ();
+
+            for (auto reloc : relocations)
+            {
+                for (auto f : m_codeObj.funcs ())
+                {
+                    if (f->entry ()->start () == reloc.getDynSym ()->getOffset ())
+                    {
+                        auto cfgSymbol = cfgInternalData->add_xrefs ();
+                        cfgSymbol->set_ea (reloc.rel_addr ());
+                        cfgSymbol->set_width (8);
+                        cfgSymbol->set_target_ea (reloc.getDynSym ()->getOffset ());
+                        cfgSymbol->set_target_name (f->name ());
+                        cfgSymbol->set_target_is_code (true);
+
+                        cfgSymbol->set_target_fixup_kind (mcsema::DataReference::Absolute);
+
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}
+
+bool CFGWriter::isExternal (Address addr) const
+{
+    if (m_codeObj.cs ()->linkage ().find (addr) != m_codeObj.cs ()->linkage ().end ())
+    {
+        return m_extFuncMgr.isExternal (m_codeObj.cs ()->linkage () [addr]);
+    }
+
+    return false;
+}
+
+const std::string& CFGWriter::getExternalName (Address addr) const
+{
+    return m_codeObj.cs ()->linkage ().at (addr);
+}
+
+bool CFGWriter::tryEval (InstructionAPI::Expression *expr,
+                         const Address ip, Address& result) const
+{
+    if (expr->eval ().format () != "[empty]")
+    {
+        result = expr->eval ().convert<Address> ();
+        return true;
+    }
+
+    if (auto bin = dynamic_cast<InstructionAPI::BinaryFunction *> (expr))
+    {
+        std::vector<InstructionAPI::InstructionAST::Ptr> args;
+        bin->getChildren (args);
+
+        Address left, right;
+
+        if (tryEval (dynamic_cast<InstructionAPI::Expression *> (args [0].get ()), ip, left)
+            && tryEval (dynamic_cast<InstructionAPI::Expression *> (args [1].get ()), ip, right))
+        {
+            if (bin->isAdd ())
+            {
+                result = left + right;
+                return true;
+            }
+            else if (bin->isMultiply ())
+            {
+                result = left * right;
+                return true;
+            }
+
+            return false;
+        }
+    }
+    else if (auto reg = dynamic_cast<InstructionAPI::RegisterAST *> (expr))
+    {
+        if (reg->format () == "RIP")
+        {
+            result = ip;
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/tools/mcsema_disass/dyninst/CFGWriter.hpp
+++ b/tools/mcsema_disass/dyninst/CFGWriter.hpp
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <Symtab.h>
+#include <CodeObject.h>
+#include <Expression.h>
+#include <CFG.pb.h>
+#include "ExternalFunctionManager.hpp"
+#include "SectionManager.hpp"
+
+class CFGWriter
+{
+public:
+    CFGWriter (mcsema::Module& m, const std::string& moduleName,
+               Dyninst::SymtabAPI::Symtab& symtab,
+               Dyninst::ParseAPI::CodeObject& codeObj,
+               const ExternalFunctionManager& extFuncMgr);
+
+    // Causes the function called "name" to be skipped (see below)
+    void skipFunction (const std::string& name);
+
+    void write ();
+
+private:
+    // Some internal functions (such as __libc_csu_init) tend to cause
+    // problems when disassembling. When the lifted code gets
+    // recompiled, the linker will add those functions again, anyways,
+    // so we just skip them here. This function returns true iff the
+    // function called "name" should be skipped.
+    bool shouldSkipFunction (const std::string& name) const;
+
+    void writeInternalFunctions ();
+    void writeBlock (Dyninst::ParseAPI::Block *block,
+                     Dyninst::ParseAPI::Function *func,
+                     mcsema::Function *cfgInternalFunc);
+    void writeInstruction (Dyninst::InstructionAPI::Instruction *instruction,
+                           Dyninst::Address addr, mcsema::Block *cfgBlock);
+    void handleCallInstruction (Dyninst::InstructionAPI::Instruction *instruction,
+                                Dyninst::Address addr, mcsema::Instruction *cfgInstruction);
+    void handleNonCallInstruction (Dyninst::InstructionAPI::Instruction *instruction,
+                                   Dyninst::Address addr, mcsema::Instruction *cfgInstruction);
+    void writeExternalFunctions ();
+    void writeInternalData ();
+
+    bool isExternal (Dyninst::Address addr) const;
+    const std::string& getExternalName (Dyninst::Address addr) const;
+    bool tryEval (Dyninst::InstructionAPI::Expression *expr,
+                  const Dyninst::Address ip, Dyninst::Address& result) const;
+
+    mcsema::Module& m_module;
+    std::string m_moduleName;
+    Dyninst::SymtabAPI::Symtab& m_symtab;
+    Dyninst::ParseAPI::CodeObject& m_codeObj;
+    const ExternalFunctionManager& m_extFuncMgr;
+
+    std::map<Dyninst::Offset,std::string> m_funcMap;
+    std::set<std::string> m_skipFuncs;
+
+    SectionManager m_sectionMgr;
+    std::vector<Dyninst::SymtabAPI::relocationEntry> m_relocations;
+};

--- a/tools/mcsema_disass/dyninst/CMakeLists.txt
+++ b/tools/mcsema_disass/dyninst/CMakeLists.txt
@@ -1,0 +1,34 @@
+if (NOT UNIX)
+  message (ERROR "The Dyninst frontend currently does not support this OS")
+else ()
+  add_compile_options(-frtti -std=gnu++1y)
+endif ()
+
+find_package(Dyninst REQUIRED)
+include_directories(${DYNINST_INCLUDE_DIR})
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../../../)
+
+set_source_files_properties(
+  ${PROJECT_PROTOBUFSOURCEFILES}
+  PROPERTIES GENERATED TRUE
+  )
+
+add_executable(mcsema-dyninst-disass
+  main.cc
+  ArgParser.cc
+  ${PROJECT_PROTOBUFSOURCEFILES}
+  CFGWriter.cc
+  ExternalFunc.cc
+  ExternalFunctionManager.cc
+  SectionManager.cc
+  )
+
+add_dependencies(mcsema-dyninst-disass generate-protobuf-files)
+
+target_link_libraries(mcsema-dyninst-disass dyninstAPI symtabAPI parseAPI common instructionAPI protobuf)
+set_property(TARGET mcsema-dyninst-disass APPEND PROPERTY CMAKE_CXX_FLAGS -frtti -std=gnu++1y)
+
+install(
+  TARGETS mcsema-dyninst-disass
+  RUNTIME DESTINATION bin
+  )

--- a/tools/mcsema_disass/dyninst/ExternalFunc.cc
+++ b/tools/mcsema_disass/dyninst/ExternalFunc.cc
@@ -1,0 +1,98 @@
+#include "ExternalFunc.hpp"
+
+ExternalFunc::ExternalFunc (const std::string& symbolName,
+                            CallingConvention callConv,
+                            bool hasReturn,
+                            bool noReturn,
+                            std::int32_t argCount,
+                            bool isWeak,
+                            const std::experimental::optional<std::string>& signature)
+    : m_symbolName (symbolName), m_callConv (callConv),
+      m_hasReturn (hasReturn), m_noReturn (noReturn),
+      m_argCount (argCount), m_isWeak (isWeak),
+      m_signature (signature)
+{
+}
+
+const std::string& ExternalFunc::symbolName () const
+{
+    return m_symbolName;
+}
+
+ExternalFunc::CallingConvention ExternalFunc::callingConvention () const
+{
+    return m_callConv;
+}
+
+mcsema::ExternalFunction::CallingConvention ExternalFunc::cfgCallingConvention () const
+{
+    switch (callingConvention ())
+    {
+    case CallingConvention::CallerCleanup:
+        return mcsema::ExternalFunction::CallerCleanup;
+    case CallingConvention::CalleeCleanup:
+        return mcsema::ExternalFunction::CalleeCleanup;
+    default:
+        return mcsema::ExternalFunction::FastCall;
+    }
+}
+
+bool ExternalFunc::hasReturn () const
+{
+    return m_hasReturn;
+}
+
+bool ExternalFunc::noReturn () const
+{
+    return m_noReturn;
+}
+
+std::int32_t ExternalFunc::argumentCount () const
+{
+    return m_argCount;
+}
+
+bool ExternalFunc::isWeak () const
+{
+    return m_isWeak;
+}
+
+const std::experimental::optional<std::string>& ExternalFunc::signature () const
+{
+    return m_signature;
+}
+
+void ExternalFunc::setSymbolName (const std::string& name)
+{
+    m_symbolName = name;
+}
+
+void ExternalFunc::setCallingConvention (CallingConvention cc)
+{
+    m_callConv = cc;
+}
+
+void ExternalFunc::setHasReturn (bool hasReturn)
+{
+    m_hasReturn = hasReturn;
+}
+
+void ExternalFunc::setNoReturn (bool noReturn)
+{
+    m_noReturn = noReturn;
+}
+
+void ExternalFunc::setArgumentCount (std::int32_t argCount)
+{
+    m_argCount = argCount;
+}
+
+void ExternalFunc::setIsWeak (bool isWeak)
+{
+    m_isWeak = isWeak;
+}
+
+void ExternalFunc::setSignature (const std::experimental::optional<std::string>& signature)
+{
+    m_signature = signature;
+}

--- a/tools/mcsema_disass/dyninst/ExternalFunc.hpp
+++ b/tools/mcsema_disass/dyninst/ExternalFunc.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <experimental/optional>
+#include <CFG.pb.h>
+
+class ExternalFunc
+{
+public:
+    bool operator< (const ExternalFunc& other) const { return m_symbolName < other.m_symbolName; }
+
+    enum class CallingConvention
+    {
+        CallerCleanup = 0,
+        CalleeCleanup = 1,
+        FastCall = 2
+    };
+
+    ExternalFunc () = default;
+    ExternalFunc (const std::string& symbolName,
+                  CallingConvention callConv,
+                  bool hasReturn,
+                  bool noReturn,
+                  std::int32_t argCount,
+                  bool isWeak,
+                  const std::experimental::optional<std::string>& signature = {});
+
+    const std::string& symbolName () const;
+    CallingConvention callingConvention () const;
+    mcsema::ExternalFunction::CallingConvention cfgCallingConvention () const;
+    bool hasReturn () const;
+    bool noReturn () const;
+    std::int32_t argumentCount () const;
+    bool isWeak () const;
+    const std::experimental::optional<std::string>& signature () const;
+
+    void setSymbolName (const std::string& name);
+    void setCallingConvention (CallingConvention cc);
+    void setHasReturn (bool hasReturn);
+    void setNoReturn (bool noReturn);
+    void setArgumentCount (std::int32_t argCount);
+    void setIsWeak (bool isWeak);
+    void setSignature (const std::experimental::optional<std::string>& signature);
+
+private:
+    std::string m_symbolName;
+    CallingConvention m_callConv;
+    bool m_hasReturn;
+    bool m_noReturn;
+    std::int32_t m_argCount;
+    bool m_isWeak;
+    std::experimental::optional<std::string> m_signature;
+};

--- a/tools/mcsema_disass/dyninst/ExternalFunctionManager.cc
+++ b/tools/mcsema_disass/dyninst/ExternalFunctionManager.cc
@@ -1,0 +1,151 @@
+#include "ExternalFunctionManager.hpp"
+#include <iostream>
+
+void ExternalFunctionManager::addExternalSymbol (const std::string& name, const ExternalFunc& func)
+{
+    m_extFuncs [name] = func;
+}
+
+void ExternalFunctionManager::addExternalSymbol (const std::string& s)
+{
+    if (s.empty ())
+        return; // Empty line
+    else if (s.front () == '#')
+        return; // Comment line
+    else if (s.substr (0, 5) == "DATA:")
+        return; // Refers to external data, not a function
+
+    std::string rest = s;
+    int n = rest.find (' ');
+
+    if (n != std::string::npos)
+    {
+        std::string symbolName = rest.substr (0, n);
+        rest = rest.substr (n + 1);
+        n = rest.find (' ');
+
+        if (n != std::string::npos)
+        {
+            std::int32_t argCount = std::stoi (rest.substr (0, n));
+            rest = rest.substr (n + 1);
+            n = rest.find (' ');
+
+            if (n != std::string::npos)
+            {
+                char cc = rest.front ();
+                ExternalFunc::CallingConvention callConv;
+
+                if (cc == 'C')
+                    callConv = ExternalFunc::CallingConvention::CallerCleanup;
+                else if (cc == 'E')
+                    callConv = ExternalFunc::CallingConvention::CalleeCleanup;
+                else if (cc == 'F')
+                    callConv = ExternalFunc::CallingConvention::FastCall;
+                else
+                {
+                    std::cerr << "Error while parsing symbol definition \""
+                              << s << "\": unknown calling convention '"
+                              << cc << "'" << std::endl;
+                    throw std::runtime_error { "error while parsing symbol definition" };
+                }
+
+                rest = rest.substr (n + 1);
+                n = rest.find (' ');
+                std::string ret;
+                std::experimental::optional<std::string> signature;
+
+                if (n != std::string::npos)
+                {
+                    ret = rest.substr (0, 1);
+                    signature = rest.substr (2);
+                }
+                else
+                    ret = rest;
+
+                bool noReturn;
+                if (ret == "N")
+                    noReturn = false;
+                else if (ret == "Y")
+                    noReturn = true;
+                else
+                {
+                    std::cerr << "Error while parsing symbol definition \""
+                              << s << "\": unknown return type specifier '"
+                              << noReturn << "'" << std::endl;
+                    throw std::runtime_error { "error while parsing symbol definition" };
+                }
+
+                ExternalFunc func (symbolName, callConv, !noReturn, noReturn,
+                                   argCount, false /* TODO? */, signature);
+
+                m_extFuncs [symbolName] = func;
+                return;
+            }
+        }
+        else
+        {
+            throw std::runtime_error { "internal McSema call convention is no longer supported" };
+        }
+    }
+
+    std::cerr << "Error while parsing symbol definition \"" << s
+              << "\": ill-formed symbol definition" << std::endl;
+
+    throw std::runtime_error { "error while parsing symbol definition" };
+}
+
+void ExternalFunctionManager::addExternalSymbols (std::istream& s)
+{
+    while (!s.eof ())
+    {
+        std::string line;
+        std::getline (s, line);
+        addExternalSymbol (line);
+    }
+}
+
+void ExternalFunctionManager::removeExternalSymbol (const std::string& name)
+{
+    m_extFuncs.erase (name);
+    m_usedFuncs.erase (name);
+}
+
+bool ExternalFunctionManager::isExternal (const std::string& name) const
+{
+    return m_extFuncs.find (name) != m_extFuncs.end ();
+}
+
+const ExternalFunc& ExternalFunctionManager::getExternalFunction (const std::string& name) const
+{
+    return m_extFuncs.at (name);
+}
+
+void ExternalFunctionManager::clearUsed ()
+{
+    m_usedFuncs.clear ();
+}
+
+void ExternalFunctionManager::markAsUsed (const std::string& name)
+{
+    m_usedFuncs.insert (name);
+}
+
+std::set<ExternalFunc> ExternalFunctionManager::getAllUsed () const
+{
+    std::set<ExternalFunc> result;
+
+    for (auto name : m_usedFuncs)
+    {
+        try
+        {
+            result.insert (m_extFuncs.at (name));
+        }
+        catch (const std::out_of_range& oor)
+        {
+            std::cerr << "error: unknown external symbol: \"" << name << "\"" << std::endl;
+            throw oor;
+        }
+    }
+
+    return result;
+}

--- a/tools/mcsema_disass/dyninst/ExternalFunctionManager.hpp
+++ b/tools/mcsema_disass/dyninst/ExternalFunctionManager.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <istream>
+#include <map>
+#include <set>
+#include <string>
+#include "ExternalFunc.hpp"
+
+class ExternalFunctionManager
+{
+public:
+    /* The following methods can be used to register external
+     * functions with the ExternalFunctionManager. If the same name is
+     * used multiple times, the information will be overwritten.
+     */
+
+    // Registers a function called "name" with info "func"
+    void addExternalSymbol (const std::string& name, const ExternalFunc& func);
+
+    // Parses s as if it were a line in a function definitions file
+    void addExternalSymbol (const std::string& s);
+
+    // Reads from s as if it were a function definitions file
+    void addExternalSymbols (std::istream& s);
+
+    // Un-mark a function as external
+    void removeExternalSymbol (const std::string& name);
+
+
+    // Returns true iff the function called "name" is external
+    bool isExternal (const std::string& name) const;
+
+    // Returns the information stored for the function called "name"
+    // and throws an exception if no such function can be found.
+    const ExternalFunc& getExternalFunction (const std::string& name) const;
+
+    /* The following methods can be used to keep track of the external
+     * functions that are actually called somewhere. This can greatly
+     * reduce the external_funcs blocks in the CFG file.
+     */
+    void clearUsed ();
+    void markAsUsed (const std::string& name);
+    std::set<ExternalFunc> getAllUsed () const;
+
+private:
+    std::map<std::string,ExternalFunc> m_extFuncs;
+    std::set<std::string> m_usedFuncs;
+};

--- a/tools/mcsema_disass/dyninst/README.md
+++ b/tools/mcsema_disass/dyninst/README.md
@@ -1,0 +1,53 @@
+# mcsema-dyninst-disass
+
+mcsema-dyninst-disass is an experimental frontend for McSema based on the [Dyninst API](http://www.dyninst.org/dyninst). Specifically, we make use of one of its subprojects, [ParseAPI](http://www.dyninst.org/parse), for binary file parsing and control flow recovery. We hereby aim to provide a free frontend for McSema, whose main development branch currently requires the proprietary [IDA Pro](https://www.hex-rays.com/products/ida) software. We hope to make McSema more accessible this way to users that do not have access to an IDA Pro license.
+
+The Dyninst frontend has been developed as part of a laboratory course at the [University of Erlangen-Nuremberg](https://www4.cs.fau.de/). It is, of course, not nearly as refined (yet?) as the IDA Pro frontend, but we have been able to successfully recompile a variety of smaller applications with it. Feel free to have a look at the ```tests/``` subdirectory to get a quick overview of what's already possible.
+
+## Dependencies
+
+You won't need IDA Pro to run mcsema-dyninst-disass, but Git, CMake, Google Protobuf and Python are still required (see the top-level McSema README.md file for details). In addition to those requirements, you will need to build and install DyninstAPI. It is available in source code form [on GitHub](https://github.com/dyninst/dyninst). Follow the instructions there on how to build and install DyninstAPI before proceeding to the next step.
+
+## Building mcsema-dyninst-disass
+
+Assuming that you've installed Dyninst to ```/usr/local/```, you need to export the following environment variables:
+
+```shell
+$ export CMAKE_PREFIX_PATH=/usr/local/lib/cmake/Dyninst
+$ export BUILD_MCSEMA_DYNINST_DISASS=1
+```
+
+The ```CMAKE_PREFIX_PATH``` environment variable tells CMake where to find the necessary Dyninst files, and the ```BUILD_MCSEMA_DYNINST_DISASS``` environment variable will cause the top-level CMakeLists.txt file to descend into the subdirectory where this frontend resides (otherwise it won't get built).
+
+Now, you should be able to build this frontend along with McSema using the ```build.sh``` script from the remill repository. Please see the top-level McSema README.md file for details.
+
+## Running the tests
+
+mcsema-dyninst-disass comes with a few test cases. To try them out, make sure you have built both this frontend as well as mcsema-lift. Then, chdir to ```mcsema/tools/mcsema_disass/dyninst/tests``` (in the source code tree), where you will find a Python script ```run_tests.py```.
+
+```shell
+$ ./run_tests.py -h
+```
+
+provides an overview of the required command line options. Supplied with the proper arguments, the script will then proceed to build, disassemble, lift and recompile the test programs in a temporary directory, each time running both the original as well as the recompiled binary and then passing the test iff the outputs match.
+
+## Using mcsema-dyninst-disass
+
+mcsema-dyninst-disass replaces the IDA Pro frontend in the sense that both take a binary file as input and produce a Google Protocol Buffer file as output. The output can then be fed into mcsema-lift for further processing.
+
+A typical invocation of mcsema-dyninst-disass might look like this:
+
+```shell
+$ mcsema-dyninst-disass -o out.cfg --std-defs [...]/mcsema/tools/mcsema_disass/defs/linux.txt [...]/a.out
+```
+
+mcsema-dyninst-disass can also accept additional external symbol definitions from the command line; use ```--help``` for a full list of available options.
+
+## Known limitations
+
+* Does not work very well at all yet with the new protobuf format
+* Can *only* handle 64-bit ELF files
+* Has *only* been tested on Linux
+* Does not yet have proper support for external data symbols
+* Cannot handle unstripped binaries yet
+* Still needs lots of debugging, corner-case handling, ...

--- a/tools/mcsema_disass/dyninst/SectionManager.cc
+++ b/tools/mcsema_disass/dyninst/SectionManager.cc
@@ -1,0 +1,42 @@
+#include "SectionManager.hpp"
+
+using namespace Dyninst;
+using namespace SymtabAPI;
+
+void SectionManager::addRegion (Region *r)
+{
+    if (m_regions.find (r) == m_regions.end ())
+        m_regions.insert (r);
+}
+
+bool SectionManager::isData (Address a) const
+{
+    auto dataRegions { getDataRegions () };
+    const Offset o = (const Offset) a;
+
+    for (auto r : dataRegions)
+    {
+        if (r->isOffsetInRegion (o))
+            return true;
+    }
+
+    return false;
+}
+
+bool SectionManager::isCode (Address a) const
+{
+    return !isData (a);
+}
+
+std::set<Region *> SectionManager::getDataRegions () const
+{
+    std::set<Region *> result;
+
+    for (Region *r : m_regions)
+    {
+        if (!r->isText ())
+            result.insert (r);
+    }
+
+    return result;
+}

--- a/tools/mcsema_disass/dyninst/SectionManager.hpp
+++ b/tools/mcsema_disass/dyninst/SectionManager.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Symtab.h>
+#include <set>
+
+class SectionManager
+{
+public:
+    void addRegion (Dyninst::SymtabAPI::Region *r);
+
+    bool isData (Dyninst::Address a) const;
+    bool isCode (Dyninst::Address a) const;
+
+    std::set<Dyninst::SymtabAPI::Region *> getDataRegions () const;
+
+private:
+    std::set<Dyninst::SymtabAPI::Region *> m_regions;
+};

--- a/tools/mcsema_disass/dyninst/main.cc
+++ b/tools/mcsema_disass/dyninst/main.cc
@@ -1,0 +1,122 @@
+#include <iostream>
+#include <fstream>
+#include <memory>
+#include <CodeObject.h>
+#include <InstructionDecoder.h>
+#include <Symtab.h>
+#include <Variable.h>
+#include <Dereference.h>
+#include <Function.h>
+#include <InstructionCategories.h>
+#include "SectionManager.hpp"
+#include "ArgParser.hpp"
+#include "ExternalFunctionManager.hpp"
+#include "CFGWriter.hpp"
+
+using namespace Dyninst;
+
+int main (int argc, char **argv)
+{
+    GOOGLE_PROTOBUF_VERIFY_VERSION;
+
+    // Parse the command line arguments
+
+    ArgParser argParser (argc, argv);
+
+    // We need exactly one input file
+
+    if (argParser.getInputFiles ().size () < 1)
+        throw std::runtime_error { "need exactly one input file" };
+    else if (argParser.getInputFiles ().size () > 1)
+        throw std::runtime_error { "more than one input file specified" };
+
+    auto inputFile = argParser.getInputFiles ().front ();
+
+    // Load external symbol definitions (for now, only functions)
+
+    ExternalFunctionManager extFuncMgr;
+
+    for (auto stdDefFile : argParser.getStdDefFiles ())
+    {
+        std::ifstream file (stdDefFile);
+        extFuncMgr.addExternalSymbols (file);
+    }
+
+    for (const auto& extSymDef : argParser.getAddExtSyms ())
+        extFuncMgr.addExternalSymbol (extSymDef);
+
+    extFuncMgr.clearUsed ();
+
+    // Set up Dyninst stuff
+
+    auto symtabCS = std::make_shared<ParseAPI::SymtabCodeSource> ((char *) inputFile.c_str ());
+    if (!symtabCS)
+        return 1;
+
+    auto symtab = symtabCS->getSymtabObject ();
+    if (!symtab)
+        return 1;
+
+    auto codeObj = std::make_shared<ParseAPI::CodeObject> (symtabCS.get ());
+    if (!codeObj)
+        return 1;
+
+    codeObj->parse ();
+
+    // Mark the functions that appear in the module as used (so that
+    // they will be listed as external symbols in the CFG file)
+
+    for (auto p : codeObj->cs ()->linkage ())
+    {
+        std::vector<SymtabAPI::Function *> fs;
+
+        // Only mark external functions
+        if (!(symtab->findFunctionsByName (fs, p.second)))
+            extFuncMgr.markAsUsed (p.second);
+    }
+
+    // This is the main Protobuf object we will write into
+
+    mcsema::Module m;
+
+    // Write the CFG information to m
+
+    CFGWriter cfgWriter (m, inputFile, *symtab, *codeObj, extFuncMgr);
+    cfgWriter.write ();
+
+    // Dump the CFG file in a human-readable format if requested
+
+    if (argParser.getDumpCfg () == true)
+    {
+        if (argParser.getPrettyPrintCfg () == false)
+            std::cout << m.DebugString () << std::endl;
+        else
+            throw std::runtime_error { "pretty-printing the new format is not yet supported" };
+    }
+
+    // Output CFG file
+
+    std::string outputFile;
+
+    if (argParser.getOutputFiles ().size () == 1)
+    {
+        auto outputFile = argParser.getOutputFiles ().front ();
+        std::ofstream out (outputFile.c_str ());
+        m.SerializeToOstream (&out);
+    }
+    else if (argParser.getOutputFiles ().size () > 1)
+        throw std::runtime_error { "multiple output files specified" };
+    /* The else block is omitted intentionally. The user might not
+     * want the CFG file, maybe because he only wants to see the
+     * human-readable format and is not interested in the CFG file.
+     * However, we do issue a warning if no output is generated at
+     * all.
+     */
+    else if ((argParser.getOutputFiles ().size () < 1)
+             && (argParser.getDumpCfg () == false))
+        std::cerr << "warning: no output generated" << std::endl;
+
+    google::protobuf::ShutdownProtobufLibrary();
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/all_data_array.c
+++ b/tools/mcsema_disass/dyninst/tests/all_data_array.c
@@ -1,0 +1,27 @@
+#define _GNU_SOURCE
+
+#include <stdio.h>
+#include <stdint.h>
+
+int main(int argc, char **args)
+{
+    uint8_t fold = 0xAF;
+    void (*obf_funcs[]) (void) = {
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+        (void (*) (void))main,
+    };
+
+    printf("hrm: %zu\n", sizeof (obf_funcs));
+    printf("hrm: %zu\n", sizeof (void *));
+    printf("div: %zu\n", (sizeof (obf_funcs) / sizeof (void *)));
+    fold %= (sizeof (obf_funcs) / sizeof (void *));
+    printf("so answer: %d\n", fold);
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/all_globals.c
+++ b/tools/mcsema_disass/dyninst/tests/all_globals.c
@@ -1,0 +1,20 @@
+#include <unistd.h>
+#include <stdlib.h>
+
+static char someglobal = 1;
+
+int writeit()
+{
+    write(2,&someglobal,1);
+    someglobal++;
+    write(2,&someglobal,1);
+    return 0;
+}
+
+int main(void)
+{
+    someglobal = 0x68;
+    writeit();
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/all_stringpool.c
+++ b/tools/mcsema_disass/dyninst/tests/all_stringpool.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, const char *argv[]) {
+    printf("%s: %s\n", "partial string test", "string test");
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/all_switch.c
+++ b/tools/mcsema_disass/dyninst/tests/all_switch.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, const char *argv[]) {
+
+	if(argc < 2) {
+		return -1;
+	}
+
+	int input = atoi(argv[1]);
+
+	switch(input) {
+		case 0: 
+			printf("Input was zero\n");
+			break;
+		case 1: 
+			printf("Input was one\n");
+			break;
+		case 2: 
+			printf("Input was two\n");
+			break;
+		case 4: 
+			printf("Input was four\n");
+			break;
+		case 6: 
+			printf("Input was six\n");
+			break;
+		case 12: 
+			printf("Input was twelve\n");
+			break;
+		case 13: 
+			printf("Input was thirteen\n");
+			break;
+		case 19: 
+			printf("Input was nineteen\n");
+			break;
+		case 255: 
+			printf("Input was two hundred fifty-five\n");
+			break;
+		case 0x12389:
+			printf("Really big input:  0x12389\n");
+			break;
+		case 0x1238A:
+			printf("Really big input:  0x1238A\n");
+			break;
+		case 0x1238B:
+			printf("Really big input:  0x1238B\n");
+			break;
+		case 0x1238C:
+			printf("Really big input:  0x1238C\n");
+			break;
+		case 0x1238D:
+			printf("Really big input:  0x1238D\n");
+			break;
+		case 0x1238F:
+			printf("Really big input:  0x1238F\n");
+			break;
+		case 0x12390:
+			printf("Really big input:  0x12390\n");
+			break;
+		case 0x12391:
+			printf("Really big input:  0x12391\n");
+			break;
+		case 0x12392:
+			printf("Really big input:  0x12392\n");
+			break;
+		case 0x12393:
+			printf("Really big input:  0x12393\n");
+			break;
+		default:
+			printf("Unknown input: %d\n", input);
+	}
+	return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/array.c
+++ b/tools/mcsema_disass/dyninst/tests/array.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int main (void)
+{
+    int array [10];
+    int sum = 0;
+
+    for (int i = 0; i < 10; ++i)
+        array [i] = 2 * i;
+
+    for (int i = 0; i < 10; ++i)
+        sum += array [i];
+
+    printf ("Result: %d\n", sum);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/bubblesort.c
+++ b/tools/mcsema_disass/dyninst/tests/bubblesort.c
@@ -1,0 +1,53 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+void bubbleSort (int a [], int array_size)
+{
+    int i, j, temp;
+
+    for (i = 0; i < array_size - 1; ++i)
+    {
+        for (j = 0; j < array_size - 1 - i; ++j)
+        {
+            if (a [j] > a [j+1])
+            {
+                temp = a [j+1];
+                a [j+1] = a [j];
+                a [j] = temp;
+            }
+        }
+    }
+}
+
+int main (int argc, char **argv)
+{
+    if (argc < 2)
+        return 1;
+
+    int size = atoi (argv [1]);
+    int i = 0;
+    int array [size];
+
+    for (int i = 0; i < size; ++i)
+        array [i] = size - i;
+
+    printf ("Before sorting the list is: \n");
+
+    for(i = 0; i < size; ++i)
+    {
+        printf ("%d ", array [i]);
+    }
+
+    bubbleSort (array, size);
+
+    printf ("\nAfter sorting the list is: \n");
+
+    for(i = 0; i < size; ++i)
+    {
+        printf ("%d ", array [i]);
+    }
+
+    printf("\n");
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/dot_product.c
+++ b/tools/mcsema_disass/dyninst/tests/dot_product.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+static const int a [] = { 4, 3, 7, 5, 9, -4 };
+static const int b [] = { 1, -1, 5, -2, 3, 5 };
+
+int main (void)
+{
+    int result = 0;
+
+    for (int i = 0; i < 6; ++i)
+        result += a[i] * b[i];
+
+    printf ("%d\n", result);
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/fibonacci.c
+++ b/tools/mcsema_disass/dyninst/tests/fibonacci.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+unsigned int fib (unsigned int i)
+{
+    if (i == 0)
+        return 0;
+    else if ((i == 1) || (i == 2))
+        return 1;
+    else
+        return fib (i - 1) + fib (i - 2);
+}
+
+int main (int argc, char **argv)
+{
+    if (argc < 2)
+        return 1;
+
+    int n = atoi (argv [1]);
+    printf ("%u\n", fib (n));
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/helloworld.c
+++ b/tools/mcsema_disass/dyninst/tests/helloworld.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+
+static const int g = 8;
+
+int foo (void)
+{
+    const int *p = &g;
+
+    if ((*p) > 12)
+        return 17;
+
+    char str [] = "Hello, world!\n";
+
+    for (int i = 0; i < 14; ++i)
+        putchar (str [i]);
+
+    putchar('H');
+    putchar('e');
+    putchar('l');
+    putchar('l');
+    putchar('o');
+    putchar(',');
+    putchar(' ');
+    putchar('w');
+    putchar('o');
+    putchar('r');
+    putchar('l');
+    putchar('d');
+    putchar('!');
+    putchar('\n');
+
+    printf ("And now from printf()!\n");
+
+    int i;
+    i = 4 + (*p);
+    printf ("Calculated %d\n", i + 42);
+
+    return 0;
+}
+
+int main (int argc, char **argv)
+{
+    return foo ();
+}

--- a/tools/mcsema_disass/dyninst/tests/libfoo_foo.c
+++ b/tools/mcsema_disass/dyninst/tests/libfoo_foo.c
@@ -1,0 +1,22 @@
+int foo (void)
+{
+    return 42;
+}
+
+int bar (int i)
+{
+    return foo () + i;
+}
+
+int baz (void)
+{
+    return bar (8) + 1;
+}
+
+int test (int i)
+{
+    if (i < 1)
+        return 0;
+    else
+        return i + test (i-1);
+}

--- a/tools/mcsema_disass/dyninst/tests/libfoo_test.c
+++ b/tools/mcsema_disass/dyninst/tests/libfoo_test.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+extern int foo (void);
+extern int bar (int);
+extern int baz (void);
+extern int test (int);
+
+int main (int argc, char **argv)
+{
+    printf ("foo(): %d (should be: 42)\n", foo ());
+    printf ("bar(15): %d (should be: 57)\n", bar (15));
+    printf ("baz(): %d (should be: 51)\n", baz ());
+    printf ("test(6): %d (should be: 21)\n", test(6));
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/local-array.c
+++ b/tools/mcsema_disass/dyninst/tests/local-array.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+
+int main (int argc, char **argv)
+{
+    int array [] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+    int result = 0;
+
+    for (int i = 0; i < 10; ++i)
+    {
+        result += array [i];
+        printf ("result now: %d\n", result);
+    }
+
+    printf ("final result: %d\n", result);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/matrix_vector_mult.c
+++ b/tools/mcsema_disass/dyninst/tests/matrix_vector_mult.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+
+static const int A [] = { 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+static const int b [] = { 4, 7, 11 };
+static int c [3] = { 0 };
+
+int main (int argc, char **argv)
+{
+    for (int i = 0; i < 3; ++i)
+    {
+        for (int j = 0; j < 3; ++j)
+        {
+            c [i] += A [3 * i + j] * b [j];
+        }
+    }
+
+    printf ("c = ( %d, %d, %d )^T\n", c [0], c [1], c [2]);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/open_close_dir.c
+++ b/tools/mcsema_disass/dyninst/tests/open_close_dir.c
@@ -1,0 +1,23 @@
+#include <sys/types.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <errno.h>
+
+int main (int argc, char **argv)
+{
+    if (argc != 2)
+    {
+        puts ("error: need exactly one argument");
+        return 1;
+    }
+
+    DIR *dir = opendir (argv [1]);
+    if (!dir)
+        perror ("opendir");
+    else
+        closedir (dir);
+
+    printf ("errno: %d\n", errno);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/pointers.c
+++ b/tools/mcsema_disass/dyninst/tests/pointers.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int main (int argc, char **argv)
+{
+    int x = 93;
+    int *y = &x;
+    int **z = &y;
+
+    printf ("  x: %d\n",   x);
+    printf (" *y: %d\n",  *y);
+    printf ("**z: %d\n", **z);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/rand_and_strtol.c
+++ b/tools/mcsema_disass/dyninst/tests/rand_and_strtol.c
@@ -1,0 +1,26 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main (void)
+{
+    int x = -11;
+    int y = abs (x);
+
+    printf ("11 : %i\n", y);
+
+    srand (13);
+
+    int i = rand ();
+    printf ("rand: %i\n", i);
+
+    char str [30] = "2030300 This is a test";
+    char *ptr;
+    long ret;
+
+    printf ("str: \"%s\"\n", str);
+    ret = strtol (str, &ptr, 10);
+    printf ("Number: %ld\n", ret);
+    printf ("Remainder: \"%s\"\n", ptr);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/readdir.c
+++ b/tools/mcsema_disass/dyninst/tests/readdir.c
@@ -1,0 +1,46 @@
+#include <dirent.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+static void lookup (const char *arg)
+{
+    DIR *dirp;
+    struct dirent *dp;
+
+    if ((dirp = opendir (".")) == NULL)
+    {
+        perror ("couldn't open '.'");
+        return;
+    }
+
+    do
+    {
+        errno = 0;
+        if ((dp = readdir (dirp)) != NULL)
+        {
+            if (strcmp (dp->d_name, arg) != 0)
+                continue;
+
+            printf ("found %s\n", arg);
+            closedir (dirp);
+            return;
+        }
+    } while (dp != NULL);
+
+    if (errno != 0)
+        perror ("error reading directory");
+    else
+        printf ("failed to find %s\n", arg);
+
+    closedir (dirp);
+    return;
+}
+
+int main (int argc, char *argv[])
+{
+    for (int i = 1; i < argc; i++)
+        lookup (argv [i]);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/run_tests.py
+++ b/tools/mcsema_disass/dyninst/tests/run_tests.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python
+
+import unittest
+import os
+import tempfile
+import shutil
+import sys
+import subprocess
+import argparse
+
+disass = None
+lift = None
+lib_dir = None
+std_defs = None
+
+class LinuxTest (unittest.TestCase):
+    def setUp (self):
+        assert disass is not None
+        assert lift is not None
+        assert lib_dir is not None
+        assert std_defs is not None
+
+        self.test_dir = tempfile.mkdtemp ()
+        self.cc = "clang"
+
+    def tearDown (self):
+        shutil.rmtree (self.test_dir)
+
+    def runTest (self, filename, *args):
+        shutil.copy (filename, self.test_dir)
+
+        source = self.test_dir + "/" + filename
+
+        # The ".exe" suffix is arbitrary
+        exe = self.test_dir + "/" + filename + ".exe"
+
+        # Build the C file
+        subprocess.check_output ([ self.cc, source, "-o", exe ], stderr = subprocess.STDOUT)
+
+        # Generate the expected output
+        expected_output = subprocess.check_output ([ exe ] + list (args), stderr = subprocess.STDOUT)
+
+        # Disassemble the binary
+        cfg = self.test_dir + "/" + filename + ".cfg"
+        subprocess.check_call ([ disass, exe, "-o", cfg, "--std-defs", std_defs ])
+
+        # Lift it
+        bc = self.test_dir + "/" + filename + ".bc"
+        subprocess.check_output ([ lift, "-os", "linux", "-arch", "amd64", "-cfg", cfg,
+                                   "-entrypoint", "main", "-output", bc ], stderr = subprocess.STDOUT)
+
+        # Recompile it
+        rcexe = self.test_dir + "/" + filename + ".rc-exe"
+        subprocess.check_call ([ self.cc, bc, "-o", rcexe, "-L", lib_dir, "-lmcsema_rt64" ])
+
+        # Generate actual output
+        actual_output = subprocess.check_output ([ rcexe ] + list (args), stderr = subprocess.STDOUT)
+
+        # Check the output
+        self.assertEqual (expected_output, actual_output)
+
+        os.remove (source)
+        os.remove (exe)
+        os.remove (cfg)
+        os.remove (bc)
+        os.remove (rcexe)
+
+    def test_all_data_array (self):
+        self.runTest ("all_data_array.c")
+
+    def test_all_globals (self):
+        self.runTest ("all_globals.c")
+
+    def test_all_stringpool (self):
+        self.runTest ("all_stringpool.c")
+
+    def test_all_switch (self):
+        self.runTest ("all_switch.c", "12")
+
+    def test_array (self):
+        self.runTest ("array.c")
+
+    def test_bubblesort (self):
+        self.runTest ("bubblesort.c", "1234")
+
+    def test_dot_product (self):
+        self.runTest ("dot_product.c")
+
+    def test_fibonacci (self):
+        self.runTest ("fibonacci.c", "26")
+
+    def test_helloworld (self):
+        self.runTest ("helloworld.c")
+
+    def test_local_array (self):
+        self.runTest ("local-array.c")
+
+    def test_matrix_vector_mult (self):
+        self.runTest ("matrix_vector_mult.c")
+
+    def test_open_close_dir (self):
+        self.runTest ("open_close_dir.c", "/usr")
+
+    def test_pointers (self):
+        self.runTest ("pointers.c")
+
+    def test_rand_and_strtol (self):
+        self.runTest ("rand_and_strtol.c")
+
+    def test_readdir (self):
+        self.runTest ("readdir.c", "readdir.c", "file-that-does-not-exist")
+
+    def test_simple_array (self):
+        self.runTest ("simple_array.c")
+
+    def test_simple_exit (self):
+        self.runTest ("simple_exit.c")
+
+    def test_simple_for_loop (self):
+        self.runTest ("simple_for_loop.c")
+
+    def test_simple_main (self):
+        self.runTest ("simple_main.c")
+
+    def test_struct (self):
+        self.runTest ("struct.c")
+
+    def test_x86_bts (self):
+        self.runTest ("x86_bts.c")
+
+    def test_x86_lodsb (self):
+        self.runTest ("x86_lodsb.c")
+
+    def test_libfoo_so (self):
+        # This test needs special handling because it builds a shared library
+
+        filename = "libfoo_foo.c"
+        shutil.copy (filename, self.test_dir)
+        shutil.copy ("libfoo_test.c", self.test_dir)
+        source = self.test_dir + "/" + filename
+        source_test = self.test_dir + "/libfoo_test.c"
+
+        so = self.test_dir + "/" + "libfoo.so"
+        subprocess.check_output ([ self.cc, source, "-o", so, "-shared", "-fPIC" ], stderr = subprocess.STDOUT)
+        exe = self.test_dir + "/" + "libfoo_test"
+        subprocess.check_output ([ self.cc, source_test, "-o", exe,
+                                   "-L", self.test_dir, "-lfoo", "-Wl,-rpath=" + self.test_dir ],
+                                 stderr = subprocess.STDOUT)
+        expected_output = subprocess.check_output ([ exe ], stderr = subprocess.STDOUT)
+
+        cfg = self.test_dir + "/" + filename + ".cfg"
+        subprocess.check_call ([ disass, so, "-o", cfg, "--std-defs", std_defs ])
+
+        bc = self.test_dir + "/" + filename + ".bc"
+        subprocess.check_output ([ lift, "-os", "linux", "-arch", "amd64", "-cfg", cfg,
+                                   "-entrypoint", "foo", "-entrypoint", "bar",
+                                   "-entrypoint", "baz", "-entrypoint", "test",
+                                   "-output", bc ], stderr = subprocess.STDOUT)
+
+        obj = self.test_dir + "/" + "foo.o"
+        subprocess.check_call ([ self.cc, bc, "-o", obj, "-c" ])
+        rcexe = self.test_dir + "/" + "libfoo_test_rc"
+        subprocess.check_call ([ self.cc, source_test, obj, "-L", lib_dir, "-lmcsema_rt64", "-o", rcexe ])
+
+        actual_output = subprocess.check_output ([ rcexe ], stderr = subprocess.STDOUT)
+
+        self.assertEqual (expected_output, actual_output)
+
+        os.remove (source)
+        os.remove (so)
+        os.remove (exe)
+        os.remove (cfg)
+        os.remove (bc)
+        os.remove (obj)
+        os.remove (rcexe)
+
+if __name__ == '__main__':
+    arg_parser = argparse.ArgumentParser (
+        formatter_class = argparse.RawDescriptionHelpFormatter)
+
+    arg_parser.add_argument ('--disass',
+                             help = "Path to the mcsema-dyninst-disass binary",
+                             required = True)
+
+    arg_parser.add_argument ('--lift',
+                             help = "Path to the mcsema-lift binary",
+                             required = True)
+
+    arg_parser.add_argument ('--lib_dir',
+                             help = "Directory that contains libmcsema_rt64.a",
+                             required = True)
+
+    arg_parser.add_argument ('--std_defs',
+                             help = "File that contains standard external symbol definitions",
+                             required = True)
+
+    args, command_args = arg_parser.parse_known_args ()
+
+    if not os.path.isfile (args.disass):
+        arg_parser.error ("{} passed to --disass is not a valid file".format (args.disass))
+        os.exit (1)
+    else:
+        disass = args.disass
+
+    if not os.path.isfile (args.lift):
+        arg_parser.error ("{} passed to --lift is not a valid file".format (args.lift))
+        os.exit (1)
+    else:
+        lift = args.lift
+
+    if not os.path.isdir (args.lib_dir):
+        arg_parser.error ("{} passed to --lib_dir is not a valid directory".format (args.lib_dir))
+        os.exit (1)
+    else:
+        lib_dir = args.lib_dir
+
+    if not os.path.isfile (args.std_defs):
+        arg_parser.error ("{} passed to --std_defs is not a valid file".format (args.std_defs))
+        os.exit (1)
+    else:
+        std_defs = args.std_defs
+
+    suite = unittest.TestLoader ().loadTestsFromTestCase (LinuxTest)
+    unittest.TextTestRunner (verbosity = 2).run (suite)

--- a/tools/mcsema_disass/dyninst/tests/simple_array.c
+++ b/tools/mcsema_disass/dyninst/tests/simple_array.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+static const int array [10] = { 4, 7, 9, 13, 1, 7, 1, 0, 4, 5 };
+
+int main (void)
+{
+    int result = 0;
+
+    for (int i = 0; i < 10; ++i)
+        result += array [i];
+
+    printf ("Result: %d\n", result);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/simple_exit.c
+++ b/tools/mcsema_disass/dyninst/tests/simple_exit.c
@@ -1,0 +1,7 @@
+#include <stdlib.h>
+
+int main (int argc, char **argv)
+{
+    exit (EXIT_SUCCESS);
+    return 1;
+}

--- a/tools/mcsema_disass/dyninst/tests/simple_for_loop.c
+++ b/tools/mcsema_disass/dyninst/tests/simple_for_loop.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int main (void)
+{
+    int i = 5;
+
+    for (i = 0; i < 85; ++i) { }
+
+    printf ("i: %d\n", i);
+
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/simple_main.c
+++ b/tools/mcsema_disass/dyninst/tests/simple_main.c
@@ -1,0 +1,4 @@
+int main (int argc, char **argv)
+{
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/struct.c
+++ b/tools/mcsema_disass/dyninst/tests/struct.c
@@ -1,0 +1,42 @@
+#include <stdio.h>
+#include <string.h>
+
+struct Book
+{
+    char title [50];
+    char author [50];
+    char subject [100];
+    int book_id;
+};
+
+void printBook (struct Book book);
+
+int main ()
+{
+    struct Book Book1;
+    struct Book Book2;
+
+    strcpy (Book1.title,   "C Programming");
+    strcpy (Book1.author,  "Nuha Ali");
+    strcpy (Book1.subject, "C Programming Tutorial");
+    Book1.book_id = 6495407;
+
+    strcpy (Book2.title,   "Telecom Billing");
+    strcpy (Book2.author,  "Zara Ali");
+    strcpy (Book2.subject, "Telecom Billing Tutorial");
+    Book2.book_id = 6495700;
+
+    printBook (Book1);
+    printBook (Book2);
+
+    return 0;
+}
+
+void printBook (struct Book book)
+{
+    printf ("Book title:   %s\n", book.title);
+    printf ("Book author:  %s\n", book.author);
+    printf ("Book subject: %s\n", book.subject);
+    printf ("Book book_id: %d\n", book.book_id);
+    printf ("\n");
+}

--- a/tools/mcsema_disass/dyninst/tests/x86_bts.c
+++ b/tools/mcsema_disass/dyninst/tests/x86_bts.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+int main(void)
+{
+    unsigned int x = 0xdeadbee0;
+    unsigned int n = 3;
+    __asm__ __volatile__ ( "bts %1,%0": "+rm"(x) : "r"(n));
+    printf("x is: %08x\n", x);
+    return 0;
+}

--- a/tools/mcsema_disass/dyninst/tests/x86_lodsb.c
+++ b/tools/mcsema_disass/dyninst/tests/x86_lodsb.c
@@ -1,0 +1,57 @@
+#include <stdio.h>
+
+static inline int mystrcmp(const char *cs,const char *ct)
+{
+    register int __res;
+    __asm__ __volatile__(
+            "cld\n"
+            "1:\n"
+            "lodsb\n"
+            "scasb\n"
+            "jne 2f\n"
+            "testb %%al,%%al\n"
+            "jne 1b\n"
+            "xorl %%eax,%%eax\n"
+            "jmp 3f\n"
+            "2:\n"
+            "sbbl %%eax,%%eax\n"
+            "orb $1,%%al\n"
+            "3:\n"
+            :"=a" (__res):"S" (cs),"D" (ct):"si","di");
+    return __res;
+}
+
+static inline char *mystrcpy(char *dest, const char *src)
+{
+    int d0, d1, d2;
+    __asm__ __volatile__(  "1:\n\t"
+            "\tlodsb\n\t"
+            "stosb\n\t"
+            "testb %%al,%%al\n\t"
+            "jne 1b"
+            : "=&S" (d0), "=&D" (d1), "=&a" (d2)
+            : "0" (src),"1" (dest)
+            : "memory");
+    return dest;
+}
+
+int main(void)
+{
+    int i;
+    char buf[] = "i am really cool too\n";
+    char str[] = "i am so cool........\n";
+    char *ret = mystrcpy(buf, str);
+    for (i=0;i<13;i++)
+        printf ("%c", buf[i]);
+    printf("\n");
+
+    buf[13] = '\0';
+
+    if(mystrcmp("i am so cool.", buf) == 0) {
+        printf("The strings match\n");
+    } else {
+        printf("The strings do not match\n");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Dear McSema maintainers,

arguably, one of the greatest obstacles to using McSema today for many people is its dependency on IDA Pro. In an effort to attack this problem, I (together with a fellow student as part of a laboratory course in computer science at the [University of Erlangen-Nuremberg](https://www4.cs.fau.de/)) have started to implement an alternative control flow recovery frontend for McSema based on the [Dyninst API](http://www.dyninst.org/dyninst).

Of course, at this point, this frontend is not nearly as refined as the IDA Pro frontend and has to be considered experimental, but we have already been able to use it to successfully lift and recompile a variety of smaller applications, some of which we have included as test cases in this pull request.

We have also included a README.md file with information regarding how to build and run mcsema-dyninst-disass. In particular, it is necessary to build and install DyninstAPI before this frontend can be built. The actual build process uses CMake and is integrated with the McSema build.

Given the experimental state of this frontend, there are still quite a few limitations. This frontend currently only supports 64-bit ELF binaries, has only been tested on Linux, does not yet support external data symbols properly, can't handle unstripped binaries and, of course, still needs lots of debugging and further development.

We hope that this pull request will enable other developers to contribute to this effort or at least help explore possible alternatives to IDA Pro as a disassembler and control flow recovery engine.

We'd be glad if you could have a look at this. Thank you!

Regards,
 Fabian Wolff (and Chris Baller)
