### PR TITLE
accumulate gep offset in value of width ptr size

### DIFF
--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -278,8 +278,10 @@ static llvm::Constant *CreateInitializedState(
 // indexed thing.
 static bool GetOffsetFromBasePtr(const llvm::GetElementPtrInst *gep_inst,
                                  uint64_t *offset_out) {
-  llvm::APInt offset(64, 0);
   llvm::DataLayout dl(gModule);
+  unsigned ptr_size = dl.getPointerSizeInBits();
+  llvm::APInt offset(ptr_size, 0);
+
   const auto found_offset = gep_inst->accumulateConstantOffset(dl, offset);
   if (found_offset) {
     *offset_out = offset.getZExtValue();


### PR DESCRIPTION
lllvm::GEPOperator::accumulateConstantOffset(datalayout, offset) fail an assert if the width of the offset (type: APInt) does not match the size of a pointer in bits for the target.  See:
https://github.com/llvm-mirror/llvm/blob/release_40/lib/IR/Operator.cpp#L23-L25

The above assert fails when I try to lift a 32-bit binary.

Making the width of offset = dl.getPointerSizeInBits() allows me to lift the binary succesfully.