### PR TITLE
Some minor fixes

### DIFF
--- a/docs/McsemaWalkthrough.md
+++ b/docs/McsemaWalkthrough.md
@@ -114,14 +114,13 @@ Once we have the program's control flow information, we can translate it to LLVM
 
 Here is the command to translate the CFG into bitcode:
 
-    mcsema-lift -os linux -arch amd64 -cfg xz.cfg -entrypoint main -output xz.bc
+    mcsema-lift -os linux -arch amd64 -cfg xz.cfg -output xz.bc
 
 Let's explore the options one by one:
 
 * `-os linux`: The CFG came from a binary for the Linux operating system. Currently the valid options are `linux` or `windows`. This option is required for certain aspects of translation, like ABI compatibility for external functions, etc. 
 * `-arch amd64`: Use instruction semantics for the `amd64` architecture. Valid options are `x86` (32-bit x86 semantics) and `amd64` (64-bit x86).
 * `-cfg xz.cfg`: The input control flow graph to convert into bitcode.
-* `-entrypoint main`: The name of the entrypoint into the translated code. This should match the value used for `-entrypoint` specified to `mcsema-disass`.
 * `-output xz.bc`: Where to write the bitcode. If the `-output` option is not specified, the bitcode will be written to stdout.
 
 The `mcsema-lift` program will output a lot of debugging information to stdout and stderr. If everything is successful, the last two lines should be something similar to:

--- a/tools/mcsema_disass/binja/util.py
+++ b/tools/mcsema_disass/binja/util.py
@@ -41,16 +41,22 @@ ENDIAN_TO_STRUCT = {
 
 def read_dword(bv, addr):
     # type: (binja.BinaryView, int) -> int
+    # Pad the data if fewer than 4 bytes are read
+    endianness = ENDIAN_TO_STRUCT[bv.endianness]
     data = bv.read(addr, 4)
-    fmt = '{}L'.format(ENDIAN_TO_STRUCT[bv.endianness])
-    return struct.unpack(fmt, data)[0]
+    padded_data = '{{:\x00{}4s}}'.format(endianness).format(data)
+    fmt = '{}L'.format(endianness)
+    return struct.unpack(fmt, padded_data)[0]
 
 
 def read_qword(bv, addr):
     # type: (binja.BinaryView, int) -> int
+    # Pad the data if fewer than 8 bytes are read
+    endianness = ENDIAN_TO_STRUCT[bv.endianness]
     data = bv.read(addr, 8)
-    fmt = '{}Q'.format(ENDIAN_TO_STRUCT[bv.endianness])
-    return struct.unpack(fmt, data)[0]
+    padded_data = '{{:\x00{}8s}}'.format(endianness).format(data)
+    fmt = '{}Q'.format(endianness)
+    return struct.unpack(fmt, padded_data)[0]
 
 
 def load_binary(path):

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -27,6 +27,7 @@ setup(name="mcsema-disass",
       author_email="mcsema@trailofbits.com",
       license='Apache 2.0',
       packages=['mcsema_disass', 'mcsema_disass.ida', 'mcsema_disass.defs', 'mcsema_disass.binja'],
+      install_requires=['protobuf==3.2.0', 'python-magic'],
       package_data={
         "mcsema_disass.defs": ["linux.txt", "windows.txt"]},
       entry_points={


### PR DESCRIPTION
Hey McSema folks!

Just some minor fixes that I made when experimenting with McSema yesterday. This includes:

* Some updates to the walk through (removing a non-existent command-line option)
* Added an `install_requires` for Python dependencies
* I had errors in the Binary Ninja disassembler when `bv.read` returned less than the number of bytes requested. I added some code to pad the returned string if required. The padding is dependent on the endianness.

Please let me know your thoughts!