### PR TITLE
Thunk resolution

### DIFF
--- a/mcsema/Arch/ABI.cpp
+++ b/mcsema/Arch/ABI.cpp
@@ -517,9 +517,12 @@ void CallingConvention::StoreReturnValue(llvm::BasicBlock *block,
     return;
   }
 
-  llvm::IRBuilder<> ir(block);
-
   auto val_type = ret_val->getType();
+  if (val_type->isVoidTy()) {
+    return;
+  }
+
+  llvm::IRBuilder<> ir(block);
   auto val_var = ReturnValVar(cc, val_type);
 
   // If it's a pointer then convert it to a pointer-sized integer.

--- a/mcsema/BC/External.cpp
+++ b/mcsema/BC/External.cpp
@@ -93,19 +93,22 @@ void DeclareExternals(const NativeModule *cfg_module) {
     auto cfg_var = reinterpret_cast<const NativeExternalVariable *>(
         entry.second->Get());
 
-    if (!gModule->getGlobalVariable(cfg_var->name)) {
+    auto ll_var = gModule->getGlobalVariable(cfg_var->name);
+    if (!ll_var) {
       LOG(INFO)
           << "Adding external variable " << cfg_var->name;
 
       auto var_type = llvm::Type::getIntNTy(
           *gContext, static_cast<unsigned>(cfg_var->size * 8));
 
-      cfg_var->address = llvm::ConstantExpr::getPtrToInt(
-          new llvm::GlobalVariable(*gModule, var_type, false,
-                                   llvm::GlobalValue::ExternalLinkage,
-                                   nullptr, cfg_var->name, nullptr,
-                                   ThreadLocalMode(cfg_var)),
-          gWordType);
+      ll_var = new llvm::GlobalVariable(*gModule, var_type, false,
+                                        llvm::GlobalValue::ExternalLinkage,
+                                        nullptr, cfg_var->name, nullptr,
+                                        ThreadLocalMode(cfg_var));
+    }
+
+    if (!cfg_var->address) {
+      cfg_var->address = llvm::ConstantExpr::getPtrToInt(ll_var, gWordType);
     }
   }
 }

--- a/tools/mcsema_disass/ida/get_cfg.py
+++ b/tools/mcsema_disass/ida/get_cfg.py
@@ -366,7 +366,7 @@ def is_thunk_by_flags(ea):
   ea_name = get_function_name(ea)
   inst, _ = decode_instruction(ea)
   if not inst:
-    DEBUG("{} at {:x} is a thunk with no code??".format(ea_name, ea))
+    DEBUG("WARNING: {} at {:x} is a thunk with no code??".format(ea_name, ea))
     return _INVALID_THUNK_ADDR
 
   # Recursively find thunk-to-thunks.
@@ -383,8 +383,6 @@ def is_thunk_by_flags(ea):
 
   if not is_external_reference(ea):
     return _INVALID_THUNK_ADDR
-
-  DEBUG("??? ea={:x} name={}".format(ea, ea_name))
 
   return True, targ_ea
 
@@ -590,9 +588,6 @@ def recover_instruction_references(I, inst, addr):
 
     if Reference.CODE == ref.type:
       is_thunk, thunk_target_ea, thunk_name = try_get_thunk_name(ref.ea)
-      if "setlocale" in ref.symbol:
-
-        DEBUG("!! is_thunk={} thunk_name={} ".format(is_thunk, thunk_name))
       if is_thunk:
         ref.ea = thunk_target_ea
         ref.symbol = thunk_name

--- a/tools/mcsema_disass/ida/get_cfg.py
+++ b/tools/mcsema_disass/ida/get_cfg.py
@@ -285,21 +285,22 @@ def undecorate_external_name(fn):
 
 _ELF_THUNKS = {}
 _NOT_ELF_THUNKS = set()
-_INVALID_THUNK = (False, None)
+_INVALID_THUNK = (False, idc.BADADDR, "")
+_INVALID_THUNK_ADDR = (False, idc.BADADDR)
 
 def is_ELF_thunk_by_structure(ea):
   """Try to manually identify an ELF thunk by its structure."""
-  global _INVALID_THUNK
+  global _INVALID_THUNK_ADDR
 
   if ".plt" not in idc.SegName(ea).lower():
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
 
   # Scan through looking for a branch, either direct or indirect.
   inst = None
   for i in range(4):  # 1 is good enough for x86, 4 for aarch64.
     inst, _ = decode_instruction(ea)
     if not inst:
-      return _INVALID_THUNK
+      return _INVALID_THUNK_ADDR
     # elif is_direct_jump(inst):
     #   ea = get_direct_branch_target(inst)
     #   inst = None
@@ -311,7 +312,7 @@ def is_ELF_thunk_by_structure(ea):
       inst = None
 
   if not inst:
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
 
   target_ea = get_reference_target(inst.ea)
   if ".got.plt" == idc.SegName(target_ea).lower():
@@ -345,9 +346,9 @@ def is_ELF_thunk_by_structure(ea):
   #     extern:0031F388                 extrn qsort:near 
 
   if is_invalid_ea(target_ea):
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
   
-  return True, undecorate_external_name(get_function_name(target_ea))
+  return True, target_ea
 
 def is_thunk_by_flags(ea):
   """Try to identify a thunk based off of the IDA flags. This isn't actually
@@ -357,16 +358,16 @@ def is_thunk_by_flags(ea):
   another thunk, then the former thing is treated as a thunk. The former
   thing will not actually follow the 'structured' form matched above, so
   we'll try to recursively match to the 'final' referenced thunk."""
-  global _INVALID_THUNK
+  global _INVALID_THUNK_ADDR
 
   if not is_thunk(ea):
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
   
   ea_name = get_function_name(ea)
   inst, _ = decode_instruction(ea)
   if not inst:
     DEBUG("{} at {:x} is a thunk with no code??".format(ea_name, ea))
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
 
   # Recursively find thunk-to-thunks.
   if is_direct_jump(inst) or is_direct_function_call(inst):
@@ -376,14 +377,16 @@ def is_thunk_by_flags(ea):
       targ_thunk_name = get_symbol_name(ea, targ_ea)
       DEBUG("Found thunk-to-thunk {:x} -> {:x}: {} to {}".format(
           ea, targ_ea, ea_name, targ_thunk_name))
-      return True, targ_thunk_name
+      return True, targ_ea
     
     DEBUG("ERROR? targ_ea={:x} is not thunk".format(targ_ea))
 
   if not is_external_reference(ea):
-    return _INVALID_THUNK
+    return _INVALID_THUNK_ADDR
 
-  return True, undecorate_external_name(ea_name)
+  DEBUG("??? ea={:x} name={}".format(ea, ea_name))
+
+  return True, targ_ea
 
 def try_get_thunk_name(ea):
   """Try to figure out if a function is actually a thunk, i.e. a function
@@ -402,19 +405,24 @@ def try_get_thunk_name(ea):
   # Try two approaches to detecting whether or not
   # something is a thunk.
   is_thunk = False
+  target_ea = idc.BADADDR
   if IS_ELF:
-    is_thunk, name = is_ELF_thunk_by_structure(ea)
+    is_thunk, target_ea = is_ELF_thunk_by_structure(ea)
 
   if not is_thunk:
-    is_thunk, name = is_thunk_by_flags(ea)
+    is_thunk, target_ea = is_thunk_by_flags(ea)
   
   if not is_thunk:
     _NOT_ELF_THUNKS.add(ea)
     return _INVALID_THUNK
 
   else:
-    _ELF_THUNKS[ea] = (is_thunk, name)
-    return is_thunk, name
+    name = get_function_name(target_ea)
+    name = undecorate_external_name(name)
+    name = get_true_external_name(name)
+    ret = (is_thunk, target_ea, name)
+    _ELF_THUNKS[ea] = ret
+    return ret
 
 def is_start_of_function(ea):
   """Returns `True` if `ea` is the start of a function."""
@@ -579,6 +587,15 @@ def recover_instruction_references(I, inst, addr):
     if ref.ea in INTERNAL_THUNK_EAS:
       ref.ea = INTERNAL_THUNK_EAS[ref.ea]
       ref.symbol = get_symbol_name(ref.ea)
+
+    if Reference.CODE == ref.type:
+      is_thunk, thunk_target_ea, thunk_name = try_get_thunk_name(ref.ea)
+      if "setlocale" in ref.symbol:
+
+        DEBUG("!! is_thunk={} thunk_name={} ".format(is_thunk, thunk_name))
+      if is_thunk:
+        ref.ea = thunk_target_ea
+        ref.symbol = thunk_name
 
     target_type = reference_target_type(ref)
     location = reference_location(ref)
@@ -1003,10 +1020,10 @@ def try_identify_as_external_function(ea):
   # First, check if it's a thunk. Some thunks are not location in exported
   # sections. Sometimes there are thunk-to-thunks, where there's a function
   # whose only instruction is a direct jump to the real thunk.
-  is_thunk, thunk_name = try_get_thunk_name(ea)
+  is_thunk, thunk_target_ea, thunk_name = try_get_thunk_name(ea)
   name = None
   if is_thunk:
-    name = get_true_external_name(thunk_name)
+    name = thunk_name
 
   elif is_external_segment(ea):
     name = get_true_external_name(get_function_name(ea))
@@ -1031,9 +1048,10 @@ def identify_thunks(func_eas):
   DEBUG("Looking for thunks")
   DEBUG_PUSH()
   for func_ea in func_eas:
-    is_thunk, name = try_get_thunk_name(func_ea)
+    is_thunk, thunk_target_ea, name = try_get_thunk_name(func_ea)
     if is_thunk:
-      DEBUG("Found thunk for {} at {:x}".format(name, func_ea))
+      DEBUG("Found thunk for {} targeting {:x} at {:x}".format(
+          name, thunk_target_ea, func_ea))
   DEBUG_POP()
 
 def identify_external_symbols():

--- a/tools/mcsema_disass/ida/util.py
+++ b/tools/mcsema_disass/ida/util.py
@@ -537,7 +537,7 @@ def _crefs_from(ea, only_one=False, check_fixup=True):
 def _xrefs_from(ea, only_one=False):
   fixup_ea = idc.GetFixupTgtOff(ea)
   seen = False
-  has_one = False
+  has_one = only_one
   if not is_invalid_ea(fixup_ea):
     seen = only_one
     has_one = True

--- a/tools/mcsema_disass/ida/util.py
+++ b/tools/mcsema_disass/ida/util.py
@@ -415,8 +415,10 @@ def is_noreturn_function(ea):
          (flags & idaapi.FUNC_NORET) and \
          "cxa_throw" not in get_symbol_name(ea)
 
-_XREFS_FROM = collections.defaultdict(set)
-_XREFS_TO = collections.defaultdict(set)
+_CREFS_FROM = collections.defaultdict(set)
+_DREFS_FROM = collections.defaultdict(set)
+_CREFS_TO = collections.defaultdict(set)
+_DREFS_TO = collections.defaultdict(set)
 
 def make_xref(from_ea, to_ea, xref_constructor, xref_size):
   """Force the data at `from_ea` to reference the data at `to_ea`."""
@@ -426,8 +428,12 @@ def make_xref(from_ea, to_ea, xref_constructor, xref_size):
 
   make_head(from_ea)
 
-  _XREFS_FROM[from_ea].add(to_ea)
-  _XREFS_TO[to_ea].add(from_ea)
+  if is_code(from_ea):
+    _CREFS_FROM[from_ea].add(to_ea)
+    _CREFS_TO[to_ea].add(from_ea)
+  else:
+    _DREFS_FROM[from_ea].add(to_ea)
+    _DREFS_TO[to_ea].add(from_ea)
 
   # If we can't make a head, then it probably means that we're at the
   # end of the binary, e.g. the last thing in the `.extern` segment.
@@ -451,8 +457,12 @@ def _stop_looking_for_xrefs(ea):
   a struct will actually be associated with the first EA of the struct. So
   if we're in a struct or something like it, and the item size is bigger than
   the address size, then we will assume it's actually in a struct."""
+  
+  if is_external_segment(ea):
+    return False
+
   if is_code(ea):
-    return True
+    return False
 
   addr_size = get_address_size_in_bytes()
   item_size = idc.ItemSize(ea)
@@ -464,61 +474,61 @@ def _xref_generator(ea, get_first, get_next):
     yield target_ea
     target_ea = get_next(ea, target_ea)
 
-def _drefs_from(ea, only_one=False):
-  flags = idc.GetFlags(ea)
-  if idc.isCode(flags):
-    return
-
-  fixup_ea = idc.GetFixupTgtOff(ea)
+def _drefs_from(ea, only_one=False, check_fixup=True):
   seen = False
   has_one = only_one
-  if not is_invalid_ea(fixup_ea) and not is_code(fixup_ea):
-    seen = only_one
-    has_one = True
-    yield fixup_ea
+  fixup_ea = idc.BADADDR
+  if check_fixup:
+    fixup_ea = idc.GetFixupTgtOff(ea)
+    if not is_invalid_ea(fixup_ea) and not is_code(fixup_ea):
+      seen = only_one
+      has_one = True
+      yield fixup_ea
 
-  if has_one and _stop_looking_for_xrefs(ea):
-    return
+    if has_one and _stop_looking_for_xrefs(ea):
+      return
 
   for target_ea in _xref_generator(ea, idaapi.get_first_dref_from, idaapi.get_next_dref_from):
-    if (target_ea != fixup_ea) : # and not is_invalid_ea(fixup_ea):
+    if target_ea != fixup_ea and not is_invalid_ea(target_ea):
       seen = only_one
       yield target_ea
       if seen:
         return
 
-  if not seen and ea in _XREFS_FROM:
-    for target_ea in _XREFS_FROM[ea]:
+  if not seen and ea in _DREFS_FROM:
+    for target_ea in _DREFS_FROM[ea]:
       yield target_ea
       seen = only_one
       if seen:
         return
 
-def _crefs_from(ea, only_one=False):
+def _crefs_from(ea, only_one=False, check_fixup=True):
   flags = idc.GetFlags(ea)
   if not idc.isCode(flags):
     return
 
-  fixup_ea = idc.GetFixupTgtOff(ea)
+  fixup_ea = idc.BADADDR
   seen = False
   has_one = only_one
-  if not is_invalid_ea(fixup_ea) and is_code(fixup_ea):
-    seen = only_one
-    has_one = True
-    yield fixup_ea
+  if check_fixup:
+    fixup_ea = idc.GetFixupTgtOff(ea)
+    if not is_invalid_ea(fixup_ea) and is_code(fixup_ea):
+      seen = only_one
+      has_one = True
+      yield fixup_ea
 
-  if has_one and _stop_looking_for_xrefs(ea):
-    return
+    if has_one and _stop_looking_for_xrefs(ea):
+      return
 
   for target_ea in _xref_generator(ea, idaapi.get_first_cref_from, idaapi.get_next_cref_from):
-    if (target_ea != fixup_ea): # and not is_invalid_ea(fixup_ea):
+    if target_ea != fixup_ea and not is_invalid_ea(target_ea):
       seen = only_one
       yield target_ea
       if seen:
         return
 
-  if not seen and ea in _XREFS_FROM:
-    for target_ea in _XREFS_FROM[ea]:
+  if not seen and ea in _CREFS_FROM:
+    for target_ea in _CREFS_FROM[ea]:
       seen = only_one
       yield target_ea
       if seen:
@@ -536,14 +546,14 @@ def _xrefs_from(ea, only_one=False):
   if has_one and _stop_looking_for_xrefs(ea):
     return
 
-  for target_ea in _drefs_from(ea, only_one):
+  for target_ea in _drefs_from(ea, only_one, check_fixup=False):
     if target_ea != fixup_ea:
       seen = only_one
       yield target_ea
       if seen:
         return
 
-  for target_ea in _crefs_from(ea, only_one):
+  for target_ea in _crefs_from(ea, only_one, check_fixup=False):
     if target_ea != fixup_ea:
       seen = only_one
       yield target_ea

--- a/tools/mcsema_lift/Lift.cpp
+++ b/tools/mcsema_lift/Lift.cpp
@@ -114,8 +114,8 @@ static void LoadLibraryIntoModule(void) {
     }
 
     auto dest_var = new llvm::GlobalVariable(
-        *mcsema::gModule, var.getValueType(), var.isConstant(),
-        var.getLinkage(), nullptr,
+        *mcsema::gModule, var.getType()->getElementType(),
+        var.isConstant(), var.getLinkage(), nullptr,
         var_name, nullptr, var.getThreadLocalMode(),
         var.getType()->getAddressSpace());
 

--- a/tools/mcsema_lift/Lift.cpp
+++ b/tools/mcsema_lift/Lift.cpp
@@ -17,11 +17,14 @@
 #include <glog/logging.h>
 #include <gflags/gflags.h>
 
+#include <iomanip>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <sstream>
-#include <iomanip>
 
+#include <llvm/IR/Function.h>
+#include <llvm/IR/GlobalVariable.h>
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 
@@ -52,6 +55,9 @@ DEFINE_string(cfg, "", "Path to the CFG file containing code to lift.");
 
 DEFINE_string(output, "", "Output bitcode file name.");
 
+DEFINE_string(library, "", "Path to an LLVM bitcode or IR file that contains "
+                           "external library definitions.");
+
 DECLARE_bool(version);
 
 DECLARE_bool(disable_optimizer);
@@ -69,6 +75,52 @@ static void PrintVersion(void) {
       << "This is mcsema-lift version: " << MCSEMA_VERSION_STRING << std::endl
       << "Built from branch: " << MCSEMA_BRANCH_NAME << std::endl
       << "Using LLVM " << LLVM_VERSION_STRING << std::endl;
+}
+
+// Load in a separate bitcode or IR library, and copy function and variable
+// declarations from that library into our module. We can use this feature
+// to provide better type information to McSema.
+static void LoadLibraryIntoModule(void) {
+  std::unique_ptr<llvm::Module> lib(
+      remill::LoadModuleFromFile(mcsema::gContext, FLAGS_library));
+
+  // Declare the functions from the library in McSema's target module.
+  for (auto &func : *lib) {
+    auto func_name = func.getName();
+    if (func_name.startswith("__mcsema") || func_name.startswith("__remill")) {
+      continue;
+    }
+    if (mcsema::gModule->getFunction(func_name)) {
+      continue;
+    }
+
+    auto dest_func = llvm::Function::Create(
+        func.getFunctionType(), func.getLinkage(),
+        func_name, mcsema::gModule);
+
+    dest_func->copyAttributesFrom(&func);
+    dest_func->setVisibility(func.getVisibility());
+  }
+
+  // Declare the global variables from the library in McSema's target module.
+  for (auto &var : lib->globals()) {
+    auto var_name = var.getName();
+    if (var_name.startswith("__mcsema") || var_name.startswith("__remill")) {
+      continue;
+    }
+
+    if (mcsema::gModule->getGlobalVariable(var_name)) {
+      continue;
+    }
+
+    auto dest_var = new llvm::GlobalVariable(
+        *mcsema::gModule, var.getValueType(), var.isConstant(),
+        var.getLinkage(), nullptr,
+        var_name, nullptr, var.getThreadLocalMode(),
+        var.getType()->getAddressSpace());
+
+    dest_var->copyAttributesFrom(&var);
+  }
 }
 
 }  // namespace
@@ -130,6 +182,10 @@ int main(int argc, char *argv[]) {
       FLAGS_cfg, (mcsema::gArch->address_size / 8));
   mcsema::gModule = remill::LoadTargetSemantics(mcsema::gContext);
   mcsema::gArch->PrepareModule(mcsema::gModule);
+
+  if (!FLAGS_library.empty()) {
+    LoadLibraryIntoModule();
+  }
 
   CHECK(mcsema::LiftCodeIntoModule(cfg_module))
       << "Unable to lift CFG from " << FLAGS_cfg << " into module "


### PR DESCRIPTION
This branch fixes a parity issue where calls to externals via thunks were lifted as calls to the lifted thunks, as opposed to going through "faster" mechanisms (e.g. wrapping the externals directly). This affected both static analysis, and quality of recompiled lifted bitcode.