### PR TITLE
This commit adds support for the x86 stdcall calling convention to th…

### DIFF
--- a/mcsema/Arch/ABI.h
+++ b/mcsema/Arch/ABI.h
@@ -43,6 +43,8 @@ class CallingConvention {
   void StoreArguments(llvm::BasicBlock *block,
                       const std::vector<llvm::Value *> &arg_vals);
 
+  void FreeArguments(llvm::BasicBlock *block);
+
   void AllocateReturnAddress(llvm::BasicBlock *block);
   void FreeReturnAddress(llvm::BasicBlock *block);
 
@@ -68,6 +70,7 @@ class CallingConvention {
   llvm::CallingConv::ID cc;
   uint64_t used_reg_bitmap;
   uint64_t num_loaded_stack_bytes;
+  uint64_t num_stored_stack_bytes;
   const char * const sp_name;
   const char * const tp_name;
   const ArgConstraint *reg_table;

--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -552,6 +552,7 @@ static void ImplementExplicitArgsExitPoint(
   }
 
   loader.FreeReturnAddress(block);
+  loader.FreeArguments(block);
 
   llvm::IRBuilder<> ir(block);
   loader.StoreReturnValue(block, ir.CreateCall(extern_func, call_args));


### PR DESCRIPTION
…e ABI argument passing constraint table. Previously I must have assumed it would come in as the C calling convention. This commit also adds support for caller cleanup of arguments when using --explicit_args.