### PR TITLE
Missing ios_base destructor

### DIFF
--- a/mcsema/OS/Linux/ABI_exceptions.cpp
+++ b/mcsema/OS/Linux/ABI_exceptions.cpp
@@ -48,6 +48,7 @@ void __cxa_call_unexpected (void*) __attribute__((noreturn));
 char* __cxa_demangle(const char* mangled_name, char* output_buffer, size_t* length, int* status);
 void* __dynamic_cast(const void* __src_ptr, const __class_type_info* __src_type, const __class_type_info* __dst_type, ptrdiff_t __src2dst);
 void _Unwind_Resume(struct _Unwind_Exception *object);
+int __cxa_atexit ( void (*f)(void *), void *p, void *d );
 
 void *malloc(size_t size);
 void *realloc(void *ptr, size_t size);
@@ -95,6 +96,7 @@ void *__mcsema_externs[] = {
   reinterpret_cast<void *>(__cxa_pure_virtual),
   reinterpret_cast<void *>(__cxa_call_unexpected),
   reinterpret_cast<void *>(__cxa_demangle),
+  reinterpret_cast<void *>(__cxa_atexit),
   reinterpret_cast<void *>(_Unwind_Resume),
   reinterpret_cast<void *>(malloc),
   reinterpret_cast<void *>(realloc),

--- a/tools/mcsema_disass/defs/linux.txt
+++ b/tools/mcsema_disass/defs/linux.txt
@@ -31,6 +31,7 @@ DATA: _etext PTR
 DATA: end PTR
 DATA: _end PTR
 
+DATA: _ZTVN10__cxxabiv117__class_type_infoE PTR
 
 __assert_fail 4 C Y
 __cxa_atexit 5 C N
@@ -68,6 +69,8 @@ _ZNSt9exceptionD2Ev 1 C N
 _ZNSt9exceptionD1Ev 1 C N
 _ZNKSt9exception4whatEv 1 C N
 _ZSt9terminatev 1 C N
+_ZNSt8ios_base4InitC1Ev 1 C N
+_ZNSt8ios_base4InitD1Ev 1 C N
 
 a2d_ASN1_OBJECT 4 C N
 a2i_ASN1_ENUMERATED 4 C N

--- a/tools/mcsema_disass/defs/linux.txt
+++ b/tools/mcsema_disass/defs/linux.txt
@@ -31,7 +31,6 @@ DATA: _etext PTR
 DATA: end PTR
 DATA: _end PTR
 
-DATA: _ZTVN10__cxxabiv117__class_type_infoE PTR
 
 __assert_fail 4 C Y
 __cxa_atexit 5 C N


### PR DESCRIPTION
The exit function fails during the destruction of `ios_base` derived objects.