### PR TITLE
Issue 423 libc abi macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,9 @@ endif()
 
 #TODO(artem): this may need some logic to select only ABIs compatible with current os/arch
 #TODO(kumarak): Disable the ABI libraries build till we don't have script to automate the generation of `ABI_libc.h`. Use pre-build library to test the --abi_libraries flag
-add_subdirectory(mcsema/OS/Linux)
+if (LINUX)
+  add_subdirectory(mcsema/OS/Linux)
+endif()
 
 install(
   TARGETS ${MCSEMA_LIFT}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 
 #TODO(artem): this may need some logic to select only ABIs compatible with current os/arch
 #TODO(kumarak): Disable the ABI libraries build till we don't have script to automate the generation of `ABI_libc.h`. Use pre-build library to test the --abi_libraries flag
-if (LINUX)
+if(UNIX AND NOT APPLE)
   add_subdirectory(mcsema/OS/Linux)
 endif()
 


### PR DESCRIPTION
The libc ABI file should be generated for MacOS and included in `OS/macos` path. Check for the OS type before including directory. 