### PR TITLE
Handle attribute error on instruction personality check

### DIFF
--- a/tools/mcsema_disass/ida/util.py
+++ b/tools/mcsema_disass/ida/util.py
@@ -201,7 +201,10 @@ def instruction_personality(arg):
   global PERSONALITIES
   if isinstance(arg, (int, long)):
     arg, _ = decode_instruction(arg)
-  p = PERSONALITIES[arg.itype]
+  try:
+    p = PERSONALITIES[arg.itype]
+  except AttributeError:
+    p = PERSONALITY_NORMAL
 
   return fixup_personality(arg, p)
 


### PR DESCRIPTION
Assign the default personality if the instruction is NoneType or there is AttributeError. 