### PR TITLE
Remove a header from ABI_libc.h

### DIFF
--- a/mcsema/OS/Linux/ABI_libc.h
+++ b/mcsema/OS/Linux/ABI_libc.h
@@ -88,7 +88,7 @@ extern char *gets(char *s);
 #include <x86_64-linux-gnu/sys/mtio.h>
 #include <x86_64-linux-gnu/sys/ttychars.h>
 #include <x86_64-linux-gnu/sys/select.h>
-#include <x86_64-linux-gnu/sys/ultrasound.h>
+//#include <x86_64-linux-gnu/sys/ultrasound.h>
 #include <x86_64-linux-gnu/sys/times.h>
 #include <x86_64-linux-gnu/sys/un.h>
 #include <x86_64-linux-gnu/sys/eventfd.h>


### PR DESCRIPTION
* Removes ultrasound.h form ABI_libc.h as it only defines macros and is not present on newer systems