### PR TITLE
Fix CFG Recovery for IDA7 to work with C++ applications

### DIFF
--- a/tools/mcsema_disass/ida7/segment.py
+++ b/tools/mcsema_disass/ida7/segment.py
@@ -335,7 +335,15 @@ def process_segments(binary_is_pie):
   """Pre-process a segment and try to fill in as many cross-references
   as is possible."""
 
-  seg_eas = [ea for ea in idautils.Segments() if not is_invalid_ea(ea)]
+  # NOTE(artem): IDA7 will add "LOAD" segments for parts of the program
+  # loaded into memory but not defined in a section. Ignore these since
+  # for normal compiler generated applications they provide no benefit
+  # but add lots of extra noise
+  def bad_seg(ea):
+    seg_name = idc.get_segm_name(ea)
+    return is_invalid_ea(ea) or "LOAD" == seg_name
+
+  seg_eas = [ea for ea in idautils.Segments() if not bad_seg(ea)]
 
   # Go through through the data segments and look for strings, and through the
   # code segments and look for instructions. One result is that we should find

--- a/tools/mcsema_disass/ida7/util.py
+++ b/tools/mcsema_disass/ida7/util.py
@@ -537,8 +537,14 @@ def make_xref(from_ea, to_ea, data_type, xref_size):
   # If we can't make a head, then it probably means that we're at the
   # end of the binary, e.g. the last thing in the `.extern` segment.
   # or in the middle of structure. Return False in such case
-  if not make_head(from_ea + xref_size):
-    return False
+  #
+  # NOTE(artem): Commenting out since this breaks recovery of C++ applications
+  # with IDA7. The failure occurs when processign references in .init_array
+  # when the below code is enabled, those references are not treated as
+  # references because make_head fails.
+  #
+  #if not make_head(from_ea + xref_size):
+  #  return False
 
   ida_bytes.del_items(from_ea, idc.DELIT_EXPAND, xref_size)
 


### PR DESCRIPTION
* Ignore "LOAD" segments
* Comment out code that made the .init_array section not have references