### PR TITLE
Make --std-defs work again for mcsema-disass

### DIFF
--- a/tools/mcsema_disass/__main__.py
+++ b/tools/mcsema_disass/__main__.py
@@ -99,13 +99,6 @@ def main():
       help="The entrypoint where disassembly should begin",
       required=True)
 
-  arg_parser.add_argument(
-      "--std-defs",
-      action='append',
-      type=str,
-      default=[],
-      help="std_defs file: definitions and calling conventions of imported functions and data")
-
   args, command_args = arg_parser.parse_known_args()
 
   if not os.path.isfile(args.binary):


### PR DESCRIPTION
* Pass --std-defs to downstream scripts instead of eating it in __main__.py. Without this, only the default definitions file ever gets loaded.