### PR TITLE
Native function improvements

### DIFF
--- a/mcsema/BC/Function.cpp
+++ b/mcsema/BC/Function.cpp
@@ -899,6 +899,7 @@ static llvm::Function *LiftFunction(
   auto lifted_func = gModule->getFunction(cfg_func->lifted_name);
   CHECK(nullptr != lifted_func)
       << "Could not find declaration for " << cfg_func->lifted_name;
+  cfg_func->function = lifted_func;
 
   // This can happen due to deduplication of functions during the
   // CFG decoding process. In practice, though, that only really

--- a/mcsema/CFG/CFG.cpp
+++ b/mcsema/CFG/CFG.cpp
@@ -394,39 +394,14 @@ static void AddXref(NativeModule *module, NativeInstruction *inst,
 }  // namespace
 
 NativeObject::NativeObject(void)
-    : forward(this),
-      ea(0),
-      name(),
-      lifted_name(),
-      is_external(false),
-      is_exported(false),
-      is_thread_local(false) {}
-
-NativeFunction::NativeFunction(void)
-    : blocks(),
-      function(nullptr) {}
+    : forward(this) {}
 
 NativeExternalFunction::NativeExternalFunction(void)
-    : is_explicit(false),
-      is_weak(false),
-      num_args(0),
-      cc(gArch->DefaultCallingConv()) {}
+    : cc(gArch->DefaultCallingConv()) {}
 
-NativeVariable::NativeVariable(void)
-    : segment(nullptr),
-      address(nullptr) {}
-
-NativeStackVariable::NativeStackVariable(void)
-    : size(0),
-      offset(0),
-      llvm_var(nullptr){}
-
-NativeExceptionFrame::NativeExceptionFrame()
-    : start_ea(0),
-      end_ea(0),
-      lp_ea(0),
-      action_index(0),
-      lp_var(nullptr){}
+NativeSegment::Entry::Entry(
+    uint64_t o_ea, uint64_t o_next_ea, NativeXref *o_xref, NativeBlob *o_blob) :
+  ea(o_ea), next_ea(o_next_ea), xref(o_xref), blob(o_blob) {}
 
 void NativeObject::ForwardTo(NativeObject *dest) const {
   if (forward != this) {

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -45,7 +45,6 @@ struct NativeSegment;
 struct NativeXref;
 
 struct NativeInstruction {
- public:
   uint64_t ea = 0;
   uint64_t lp_ea = 0;
   std::string bytes;
@@ -62,7 +61,6 @@ struct NativeInstruction {
 };
 
 struct NativeBlock {
- public:
   uint64_t ea = 0;
   std::string lifted_name;
   std::vector<const NativeInstruction *> instructions;
@@ -74,7 +72,6 @@ struct NativeBlock {
 // have meaningful and unique effective addresses, usually pointing to
 // some kind of relocation section within the binary.
 struct NativeObject {
- public:
   NativeObject(void);
 
   // Forwarding pointer to resolve duplicates and such.
@@ -95,7 +92,6 @@ struct NativeObject {
 
 // Function that is defined inside the binary.
 struct NativeFunction : public NativeObject {
- public:
   std::unordered_map<uint64_t, const NativeBlock *> blocks;
   std::vector<struct NativeStackVariable *> stack_vars;
   std::vector<struct NativeExceptionFrame *> eh_frame;
@@ -105,7 +101,6 @@ struct NativeFunction : public NativeObject {
 };
 
 struct NativeStackVariable : public NativeObject {
- public:
   uint64_t size = 0;
   int64_t offset = 0;
   std::unordered_map<uint64_t, int64_t> refs;
@@ -113,7 +108,6 @@ struct NativeStackVariable : public NativeObject {
 };
 
 struct NativeExceptionFrame : public NativeObject {
- public:
   uint64_t start_ea = 0;
   uint64_t end_ea = 0;
   uint64_t lp_ea = 0;
@@ -124,7 +118,6 @@ struct NativeExceptionFrame : public NativeObject {
 
 // Function that is defined outside of the binary.
 struct NativeExternalFunction : public NativeFunction {
- public:
   NativeExternalFunction(void);
 
   bool is_explicit = false;
@@ -135,21 +128,18 @@ struct NativeExternalFunction : public NativeFunction {
 
 // Global variable defined inside of the lifted binary.
 struct NativeVariable : public NativeObject {
- public:
   const NativeSegment *segment = nullptr;
   mutable llvm::Constant *address = nullptr;
 };
 
 // Global variable defined outside of the lifted binary.
 struct NativeExternalVariable : public NativeVariable {
- public:
   uint64_t size = 0;
   bool is_weak;
 };
 
 // A cross-reference to something.
 struct NativeXref {
- public:
   enum FixupKind {
     kAbsoluteFixup,
     kThreadLocalOffsetFixup
@@ -171,13 +161,11 @@ struct NativeXref {
 };
 
 struct NativeBlob {
- public:
   uint64_t ea = 0;
   std::string data;
 };
 
 struct NativeSegment : public NativeObject {
- public:
   struct Entry {
     Entry(void) = default;
     Entry(uint64_t, uint64_t, NativeXref *, NativeBlob *);
@@ -204,7 +192,6 @@ struct NativeSegment : public NativeObject {
 using SegmentMap = std::map<uint64_t, NativeSegment *>;
 
 struct NativeModule {
- public:
   std::unordered_set<uint64_t> exported_vars;
   std::unordered_set<uint64_t> exported_funcs;
 

--- a/mcsema/CFG/CFG.h
+++ b/mcsema/CFG/CFG.h
@@ -46,24 +46,24 @@ struct NativeXref;
 
 struct NativeInstruction {
  public:
-  uint64_t ea;
-  uint64_t lp_ea;
+  uint64_t ea = 0;
+  uint64_t lp_ea = 0;
   std::string bytes;
 
-  const NativeXref *flow;
-  const NativeXref *mem;
-  const NativeXref *imm;
-  const NativeXref *disp;
-  const NativeXref *offset_table;
+  const NativeXref *flow = nullptr;
+  const NativeXref *mem = nullptr;
+  const NativeXref *imm = nullptr;
+  const NativeXref *disp = nullptr;
+  const NativeXref *offset_table = nullptr;
 
-  const NativeStackVariable *stack_var;
+  const NativeStackVariable *stack_var = nullptr;
 
   bool does_not_return;
 };
 
 struct NativeBlock {
  public:
-  uint64_t ea;
+  uint64_t ea = 0;
   std::string lifted_name;
   std::vector<const NativeInstruction *> instructions;
   std::unordered_set<uint64_t> successor_eas;
@@ -80,13 +80,13 @@ struct NativeObject {
   // Forwarding pointer to resolve duplicates and such.
   mutable NativeObject *forward;
 
-  uint64_t ea;
+  uint64_t ea = 0;
   std::string name;  // Name in the binary.
   std::string lifted_name;  // Name in the bitcode.
 
-  bool is_external;
-  bool is_exported;
-  bool is_thread_local;
+  bool is_external = false;
+  bool is_exported = false;
+  bool is_thread_local = false;
 
   void ForwardTo(NativeObject *dest) const;
   const NativeObject *Get(void) const;
@@ -96,35 +96,29 @@ struct NativeObject {
 // Function that is defined inside the binary.
 struct NativeFunction : public NativeObject {
  public:
-  NativeFunction(void);
-
   std::unordered_map<uint64_t, const NativeBlock *> blocks;
   std::vector<struct NativeStackVariable *> stack_vars;
   std::vector<struct NativeExceptionFrame *> eh_frame;
-  llvm::Function *function;
-  mutable llvm::Value *stack_ptr_var;
-  mutable llvm::Value *frame_ptr_var;
+  mutable llvm::Function *function = nullptr;
+  mutable llvm::Value *stack_ptr_var = nullptr;
+  mutable llvm::Value *frame_ptr_var = nullptr;
 };
 
 struct NativeStackVariable : public NativeObject {
  public:
-  NativeStackVariable(void);
-
-  uint64_t size;
-  int64_t offset;
+  uint64_t size = 0;
+  int64_t offset = 0;
   std::unordered_map<uint64_t, int64_t> refs;
-  mutable llvm::Value *llvm_var;
+  mutable llvm::Value *llvm_var = nullptr;
 };
 
 struct NativeExceptionFrame : public NativeObject {
  public:
-  NativeExceptionFrame(void);
-
-  uint64_t start_ea;
-  uint64_t end_ea;
-  uint64_t lp_ea;
-  uint64_t action_index;
-  mutable llvm::Value *lp_var;
+  uint64_t start_ea = 0;
+  uint64_t end_ea = 0;
+  uint64_t lp_ea = 0;
+  uint64_t action_index = 0;
+  mutable llvm::Value *lp_var = nullptr;
   std::unordered_map<uint64_t, NativeExternalVariable *> type_var;
 };
 
@@ -133,25 +127,23 @@ struct NativeExternalFunction : public NativeFunction {
  public:
   NativeExternalFunction(void);
 
-  bool is_explicit;
-  bool is_weak;
-  unsigned num_args;
+  bool is_explicit = false;
+  bool is_weak = false;
+  unsigned num_args = 0;
   llvm::CallingConv::ID cc;
 };
 
 // Global variable defined inside of the lifted binary.
 struct NativeVariable : public NativeObject {
  public:
-  NativeVariable(void);
-
-  const NativeSegment *segment;
-  mutable llvm::Constant *address;
+  const NativeSegment *segment = nullptr;
+  mutable llvm::Constant *address = nullptr;
 };
 
 // Global variable defined outside of the lifted binary.
 struct NativeExternalVariable : public NativeVariable {
  public:
-  uint64_t size;
+  uint64_t size = 0;
   bool is_weak;
 };
 
@@ -163,45 +155,47 @@ struct NativeXref {
     kThreadLocalOffsetFixup
   };
 
-  uint64_t width;  // In bytes.
-  uint64_t ea;  // Location of the xref within its segment.
-  uint64_t mask;  // Bitmask to apply to this xref. Zero if none.
-  const NativeSegment *segment;  // Segment containing the xref.
+  uint64_t width = 0;  // In bytes.
+  uint64_t ea = 0;  // Location of the xref within its segment.
+  uint64_t mask = 0;  // Bitmask to apply to this xref. Zero if none.
+  const NativeSegment *segment = nullptr;  // Segment containing the xref.
 
-  uint64_t target_ea;
+  uint64_t target_ea = 0;
   std::string target_name;
-  const NativeSegment *target_segment;  // Target segment of the xref, if any.
+  const NativeSegment *target_segment = nullptr;  // Target segment of the xref, if any.
 
   FixupKind fixup_kind;
 
-  const NativeVariable *var;
-  const NativeFunction *func;
+  const NativeVariable *var = nullptr;
+  const NativeFunction *func = nullptr;
 };
 
 struct NativeBlob {
  public:
-  uint64_t ea;
+  uint64_t ea = 0;
   std::string data;
 };
 
 struct NativeSegment : public NativeObject {
  public:
   struct Entry {
-   public:
-    uint64_t ea;
-    uint64_t next_ea;
-    const NativeXref *xref;
-    const NativeBlob *blob;
+    Entry(void) = default;
+    Entry(uint64_t, uint64_t, NativeXref *, NativeBlob *);
+
+    uint64_t ea = 0;
+    uint64_t next_ea = 0;
+    const NativeXref *xref = nullptr;
+    const NativeBlob *blob = nullptr;
   };
 
-  uint64_t size;
-  bool is_read_only;
+  uint64_t size = 0;
+  bool is_read_only = false;
 
   // Partition of entries, which are either cross-references, or opaque
   // blobs of bytes. The ordering of entries is significant.
   std::map<uint64_t, Entry> entries;
 
-  mutable llvm::GlobalVariable *seg_var;
+  mutable llvm::GlobalVariable *seg_var = nullptr;
 };
 
 // NOTE(pag): Using an `std::map` (as opposed to an `std::unordered_map`) is


### PR DESCRIPTION
`NativeFunction` `function` attribute is now properly set in case someone will need to use it.

There are some codestyle changes as well, `Native` family has now proper default inicialization.