### PR TITLE
Check for the xref variable before calling lazy init

### DIFF
--- a/mcsema/BC/Segment.cpp
+++ b/mcsema/BC/Segment.cpp
@@ -488,8 +488,12 @@ static llvm::Constant *FillDataSegment(const NativeSegment *cfg_seg,
       //    .long   _ZTI12out_of_range&-1
       //    .long   _ZTI17special_condition&-1
       } else if (val_size < gArch->address_size) {
-        LazyInitXRef(xref, val_type, val);
-        val = llvm::ConstantInt::getNullValue(val_type);
+        if (xref->var != nullptr) {
+          LazyInitXRef(xref, val_type, val);
+          val = llvm::ConstantInt::getNullValue(val_type);
+        }else {
+          val = llvm::ConstantExpr::getTrunc(val, val_type);
+        }
       }
 
       CHECK(val->getType() == entry_type)

--- a/mcsema/BC/Segment.cpp
+++ b/mcsema/BC/Segment.cpp
@@ -491,7 +491,7 @@ static llvm::Constant *FillDataSegment(const NativeSegment *cfg_seg,
         if (xref->var != nullptr) {
           LazyInitXRef(xref, val_type, val);
           val = llvm::ConstantInt::getNullValue(val_type);
-        }else {
+        } else {
           val = llvm::ConstantExpr::getTrunc(val, val_type);
         }
       }

--- a/mcsema/CFG/CFG.cpp
+++ b/mcsema/CFG/CFG.cpp
@@ -163,10 +163,6 @@ static bool ResolveReference(NativeModule *module, NativeXref *xref) {
     }
   }
 
-  if (xref->target_segment) {
-    return true;
-  }
-
   // Try to recover by finding a local variable.
   for (const auto &entry : module->ea_to_var) {
     auto var = entry.second;


### PR DESCRIPTION
The lazy initialization fails because the xref variable is not resolved. Instead of using the lazy initialization, truncate and statically assign it. 