### PR TITLE
Various fixes

### DIFF
--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -735,7 +735,7 @@ llvm::Function *GetLiftedToNativeExitPoint(ExitPointKind kind) {
 
   auto pc = remill::LoadProgramCounter(block);
   auto func_ptr_ty = llvm::PointerType::get(
-      llvm::FunctionType::get(call_args[0]->getType(), arg_types, false), 0);
+      llvm::FunctionType::get(remill::AddressType(gModule), arg_types, false), 0);
 
   llvm::IRBuilder<> ir(block);
   loader.StoreReturnValue(

--- a/mcsema/BC/Callback.cpp
+++ b/mcsema/BC/Callback.cpp
@@ -721,9 +721,6 @@ llvm::Function *GetLiftedToNativeExitPoint(ExitPointKind kind) {
 
   remill::CloneBlockFunctionInto(callback_func);
 
-  // We don't want this function to be inlined, since it was causing problems
-  // with llvm optimizations run by runO3
-
   CallingConvention loader(gArch->DefaultCallingConv());
 
   auto block = &(callback_func->back());

--- a/mcsema/BC/Segment.cpp
+++ b/mcsema/BC/Segment.cpp
@@ -263,7 +263,7 @@ static llvm::Function *CreateMcSemaInitFiniImpl(
   auto arr_type = llvm::ArrayType::get(el_type, new_elems.size());
   auto arr_init = llvm::ConstantArray::get(arr_type, new_elems);
   auto arr = new llvm::GlobalVariable(
-      *gModule, arr_type, true /* isConstant */,
+      *gModule, arr_type, false /* isConstant */,
       llvm::GlobalVariable::AppendingLinkage,
       arr_init, global_ctors ? "__mcsema.temp_array" : arr_name);
 


### PR DESCRIPTION
Fix of #547 and #546 

Replaces
`@llvm.global_ctors = appending constant` 
with
`@llvm.global_ctors = appending global`
which should be the more correct way.